### PR TITLE
[FABC-875] Fix Go Version in ci.props

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,9 @@ PKGNAME = github.com/hyperledger/$(PROJECT_NAME)
 
 METADATA_VAR = Version=$(PROJECT_VERSION)
 
-GO_VER = $(shell grep "GO_VER" ci.properties | cut -d '=' -f2-)
+# hardcode until release jobs migrate to new CI
+# GO_VER = $(shell grep "GO_VER" ci.properties | cut -d '=' -f2-)
+GO_VER = 1.12.9
 GO_SOURCE := $(shell find . -name '*.go')
 GO_LDFLAGS = $(patsubst %,-X $(PKGNAME)/lib/metadata.%,$(METADATA_VAR))
 export GO_LDFLAGS

--- a/ci.properties
+++ b/ci.properties
@@ -5,7 +5,7 @@ FAB_BASEIMAGE_VERSION=0.4.15
 # Pull below list of images from Hyperledger Docker Hub
 FAB_THIRDPARTY_IMAGES_LIST=kafka zookeeper couchdb
 # Set compatible go version
-GO_VER=1.12.9
+GO_VER=1.12.5
 # Pull below list of images from nexus3 for e2e tests
 FAB_IMAGES_LIST=javaenv nodeenv
 # Set related rocketChat channel name. Default: jenkins-robot

--- a/scripts/check_license
+++ b/scripts/check_license
@@ -31,7 +31,9 @@ function filterExcludedFiles {
 		| grep -v "\.pb\.go$" \
 		| grep -v ".gitignore" \
 		| grep -v "ci.properties" \
-        | grep -v "\.xml$" \
+        	| grep -v "\.xml$" \
+		| grep -v "\.mod$" \
+		| grep -v "\.sum" \
 		| sort -u`
 
   CHECK=$(filterGeneratedFiles "$CHECK")

--- a/scripts/check_lint
+++ b/scripts/check_lint
@@ -5,8 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-GOLINT="$GOPATH/bin/golint"
-
 function runlint {
    for dir in `ls`
    do
@@ -15,7 +13,7 @@ function runlint {
          vendor|bin|testdata|scripts)
            ;;
         *)
-           $GOLINT $dir/...
+           golint $dir/...
            ;;
         esac
       fi


### PR DESCRIPTION
This file is still sourced by the nightly CI jobs for setting the go version for the job. Needs to be reverted to an existing version until we migrate release jobs. I mistakenly changed it in my last commit.

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>