### PR TITLE
[FABC-877] Reduce scope of tests with ssl off

### DIFF
--- a/images/fabric-ca-fvt/payload/fabric-ca_utils
+++ b/images/fabric-ca-fvt/payload/fabric-ca_utils
@@ -10,8 +10,8 @@ export FABRIC_CA_SERVEREXEC="/usr/local/bin/fabric-ca-server"
 export TESTDATA="$FABRIC_CA/testdata"
 export SCRIPTDIR="$FABRIC_CA/scripts/fvt"
 export MYSQL_PORT="3306"
-export LDAP_PORT="389"
-export LDAP_PROTO="ldap://"
+export LDAP_PORT="636"
+export LDAP_PROTO="ldaps://"
 export POSTGRES_PORT="5432"
 export PGPASSWORD='postgres'
 export MSP_KEY_DIR='msp/keystore'
@@ -27,6 +27,7 @@ export TLS_CLIENTKEY="$FABRIC_CA_DATA/FabricTlsClientEEkey.pem"
 export CA_HOST_ADDRESS="localhost"
 export PROXY_PORT="7054"
 export CA_DEFAULT_PORT="1${PROXY_PORT}"
+export PROTO="https://"
 
 DATE='date +%Y-%m-%d'
 TIME='date +%I:%M:%S%p'
@@ -37,19 +38,6 @@ TimeStamp() {
 
 tolower() {
   echo "$1" | tr [:upper:] [:lower:]
-}
-
-setTLS() {
-   PROTO="http://"
-   TLSOPT=""
-   # if not set, default to OFF
-   if test -n "$FABRIC_TLS"; then
-     # otherwise, set TLS-related stuff
-     if $($FABRIC_TLS); then
-        PROTO="https://"
-        TLSOPT="--tls.certfiles $TLS_ROOTCERT"
-     fi
-   fi
 }
 
 ErrorMsg() {
@@ -250,8 +238,6 @@ enroll() {
    test -d "$FABRIC_CA_ENROLLMENT_DIR" || mkdir -p "$FABRIC_CA_ENROLLMENT_DIR"
    ENROLLCONFIG="$FABRIC_CA_ENROLLMENT_DIR/enroll.yaml"
 
-   # Determines the PROTO and TLSOPT values based on FABRIC_TLS setting
-   setTLS
    $FABRIC_CA_CLIENTEXEC enroll -u "${PROTO}${username}:${userpswd}@${CA_HOST_ADDRESS}:$PROXY_PORT" $TLSOPT \
                          -c $ENROLLCONFIG \
                          --csr.hosts "$username@fab-client.raleigh.ibm.com" \
@@ -285,7 +271,7 @@ reenroll() {
    test -d "$FABRIC_CA_CLIENT_HOME" || mkdir -p "$FABRIC_CA_CLIENT_HOME"
    ENROLLCONFIG="$FABRIC_CA_CLIENT_HOME/enroll.yaml"
    export FABRIC_CA_CLIENT_HOME
-   setTLS
+
    $FABRIC_CA_CLIENTEXEC reenroll -u $PROTO${CA_HOST_ADDRESS}:$PROXY_PORT $TLSOPT -c $ENROLLCONFIG
    RC=$?
    $($FABRIC_CA_DEBUG) && printAuth $FABRIC_CA_CERT_FILE $FABRIC_CA_KEY_FILE
@@ -312,7 +298,6 @@ register() {
    : ${FABRIC_CA_CLIENT_HOME:="$CA_CFG_PATH/$REGISTRAR"}
 
    export FABRIC_CA_ENROLLMENT_DIR
-   setTLS
    $FABRIC_CA_CLIENTEXEC register -u "$PROTO${CA_HOST_ADDRESS}:$PROXY_PORT" $TLSOPT \
                            --id.name "$USERNAME" \
                            --id.type "$USERTYPE" \
@@ -332,7 +317,6 @@ function genRunconfig() {
    local serverKey="$5"
    local maxEnroll="$6"
    local version="$7"
-   : ${FABRIC_TLS:='false'}
    : ${FABRIC_CA_DEBUG:='false'}
    local registry=""
 

--- a/scripts/fvt/affiliation_modify_test.sh
+++ b/scripts/fvt/affiliation_modify_test.sh
@@ -314,7 +314,6 @@ export -f register
 export CA_CFG_PATH=$TESTDIR
 $SCRIPTDIR/fabric-ca_setup.sh -D -R -x $TESTDIR
 mkdir -p $TESTDIR
-setTLS
 URI="-u ${PROTO}@$CA_HOST_ADDRESS:$PROXY_PORT $TLSOPT"
 
 echo -e "\n\n\n =============> Setting up Server"

--- a/scripts/fvt/backwards_comp_test.sh
+++ b/scripts/fvt/backwards_comp_test.sh
@@ -20,10 +20,6 @@ DBNAME=fabric_ca
 function genConfig {
   local version=$1
   : ${version:=""}
-    postgresTls='sslmode=disable'
-   case "$FABRIC_TLS" in
-      true) postgresTls='sslmode=require'; mysqlTls='?tls=custom' ;;
-   esac
 
    mkdir -p $FABRIC_CA_SERVER_HOME
    # Create base configuration using mysql
@@ -32,14 +28,7 @@ debug: true
 
 db:
   type: mysql
-  datasource: root:mysql@tcp(localhost:$MYSQL_PORT)/$DBNAME$mysqlTls
-  tls:
-     enabled: $FABRIC_TLS
-     certfiles:
-       - $TLS_ROOTCERT
-     client:
-       certfile: $TLS_CLIENTCERT
-       keyfile: $TLS_CLIENTKEY
+  datasource: root:mysql@tcp(localhost:$MYSQL_PORT)/$DBNAME
 
 registry:
   # Maximum number of times a password/secret can be reused for enrollment
@@ -78,7 +67,7 @@ EOF
 
   if [[ $driver = "postgres" ]]; then
     sed -i "s/type: mysql/type: postgres/
-        s/datasource:.*/datasource: host=localhost port=$POSTGRES_PORT user=postgres password=postgres dbname=$DBNAME $postgresTls/" $TESTCONFIG
+        s/datasource:.*/datasource: host=localhost port=$POSTGRES_PORT user=postgres password=postgres dbname=$DBNAME/" $TESTCONFIG
   fi
 
 }

--- a/scripts/fvt/db_smoke_test.sh
+++ b/scripts/fvt/db_smoke_test.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+SCRIPTDIR="$GOPATH/src/github.com/hyperledger/fabric-ca/scripts/fvt"
+MYSQLSMOKECONFIG=$FABRIC_CA_DATA/smoke/caconfig.yml
+
+mkdir -p "$(dirname ${MYSQLSMOKECONFIG})"
+# Create base configuration using mysql
+cat >$MYSQLSMOKECONFIG <<EOF
+debug: true
+
+db:
+  type: mysql
+  datasource: root:mysql@tcp(localhost:$MYSQL_PORT)/fabric_ca?tls=custom
+  tls:
+     enabled: true
+     certfiles:
+       - $TLS_ROOTCERT
+     client:
+       certfile: $TLS_CLIENTCERT
+       keyfile: $TLS_CLIENTKEY
+tls:
+  enabled: true
+  certfile: $TLS_SERVERCERT
+  keyfile: $TLS_SERVERKEY
+
+registry:
+  # Maximum number of times a password/secret can be reused for enrollment
+  # (default: -1, which means there is no limit)
+  maxenrollments: -1
+
+  # Contains identity information which is used when LDAP is disabled
+  identities:
+     - name: a
+       pass: b
+       type: client
+       affiliation: ""
+       maxenrollments: -1
+       attrs:
+          hf.Registrar.Roles: "client,user,peer,validator,auditor"
+          hf.Registrar.DelegateRoles: "client,user,validator,auditor"
+          hf.Revoker: true
+          hf.IntermediateCA: true
+
+affiliations:
+   org1:
+      - department1
+      - department2
+   org2:
+      - department1
+EOF
+
+fabric-ca-server start -b a:b -c $MYSQLSMOKECONFIG -d &
+if test $? -eq 1; then
+  ErrorMsg "Failed to start server, with the latest configuration file version"
+fi
+$SCRIPTDIR/fabric-ca_setup.sh -K

--- a/scripts/fvt/db_test.sh
+++ b/scripts/fvt/db_test.sh
@@ -68,11 +68,6 @@ function checkAff {
 }
 
 function genConfig {
-    postgresTls='sslmode=disable'
-   case "$FABRIC_TLS" in
-      true) postgresTls='sslmode=require'; mysqlTls='?tls=custom' ;;
-   esac
-
    mkdir -p $FABRIC_CA_SERVER_HOME
    # Create base configuration using mysql
    cat > $MYSQLSERVERCONFIG <<EOF
@@ -80,17 +75,10 @@ debug: true
 
 db:
   type: mysql
-  datasource: root:mysql@tcp(localhost:$MYSQL_PORT)/fabric_ca$mysqlTls
-  tls:
-     enabled: $FABRIC_TLS
-     certfiles:
-       - $TLS_ROOTCERT
-     client:
-       certfile: $TLS_CLIENTCERT
-       keyfile: $TLS_CLIENTKEY
+  datasource: root:mysql@tcp(localhost:$MYSQL_PORT)/fabric_ca
 
 tls:
-  enabled: $FABRIC_TLS
+  enabled: true
   certfile: $TLS_SERVERCERT
   keyfile: $TLS_SERVERKEY
 
@@ -139,7 +127,7 @@ EOF
    cp $MYSQLSERVERCONFIG $PGSQLSERVERCONFIG
    cp $MYSQLSERVERCONFIG2 $PGSQLSERVERCONFIG2
    sed -i "s/type: mysql/type: postgres/
-          s/datasource:.*/datasource: host=localhost port=$POSTGRES_PORT user=postgres password=postgres dbname=fabric_ca $postgresTls/" \
+          s/datasource:.*/datasource: host=localhost port=$POSTGRES_PORT user=postgres password=postgres dbname=fabric_ca/" \
    $PGSQLSERVERCONFIG $PGSQLSERVERCONFIG2
 }
 

--- a/scripts/fvt/enrollments_test.sh
+++ b/scripts/fvt/enrollments_test.sh
@@ -29,14 +29,8 @@ debug: true
 db:
   type: $DRIVER
   datasource: $DATASRC
-  tls:
-    certfiles:
-      - $TLS_ROOTCERT
-    client:
-      certfile: $TLS_CLIENTCERT
-      keyfile: $TLS_CLIENTKEY
 tls:
-  enabled: $FABRIC_TLS
+  enabled: true
   certfile: $TLS_SERVERCERT
   keyfile: $TLS_SERVERKEY
 ca:
@@ -97,14 +91,9 @@ debug: true
 db:
   type: $DRIVER
   datasource: $DATASRC
-  tls:
-    certfiles:
-      - $TLS_ROOTCERT
-    client:
-      certfile: $TLS_CLIENTCERT
-      keyfile: $TLS_CLIENTKEY
+
 tls:
-  enabled: $FABRIC_TLS
+  enabled: true
   certfile: $TLS_SERVERCERT
   keyfile: $TLS_SERVERKEY
 ca:

--- a/scripts/fvt/fabric-ca_setup.sh
+++ b/scripts/fvt/fabric-ca_setup.sh
@@ -13,140 +13,140 @@ ARCH="amd64"
 RC=0
 
 function usage() {
-   echo "ARGS:"
-   echo "  -d)   <DRIVER> - [sqlite3|mysql|postgres]"
-   echo "  -n)   <FABRIC_CA_INSTANCES> - number of servers to start"
-   echo "  -t)   <KEYTYPE> - rsa|ecdsa"
-   echo "  -l)   <KEYLEN> - ecdsa: 256|384|521; rsa 2048|3072|4096"
-   echo "  -c)   <SRC_CERT> - pre-existing server cert"
-   echo "  -k)   <SRC_KEY> - pre-existing server key"
-   echo "  -x)   <DATADIR> - local storage for client auth_info"
-   echo "FLAGS:"
-   echo "  -D)   set FABRIC_CA_DEBUG='true'"
-   echo "  -R)   set RESET='true' - delete DB, server certs, client certs"
-   echo "  -I)   set INIT='true'  - run fabric-ca server init"
-   echo "  -S)   set START='true' - start \$FABRIC_CA_INSTANCES number of servers"
-   echo "  -X)   set PROXY='true' - start haproxy for \$FABRIC_CA_INSTANCES of fabric-ca servers"
-   echo "  -K)   set KILL='true'  - kill all running fabric-ca instances and haproxy"
-   echo "  -L)   list all running fabric-ca instances"
-   echo "  -P)   Enable profiling port on the server"
-   echo " ?|h)  this help text"
-   echo ""
-   echo "Defaults: -d sqlite3 -n 1 -k ecdsa -l 256"
+  echo "ARGS:"
+  echo "  -d)   <DRIVER> - [sqlite3|mysql|postgres]"
+  echo "  -n)   <FABRIC_CA_INSTANCES> - number of servers to start"
+  echo "  -t)   <KEYTYPE> - rsa|ecdsa"
+  echo "  -l)   <KEYLEN> - ecdsa: 256|384|521; rsa 2048|3072|4096"
+  echo "  -c)   <SRC_CERT> - pre-existing server cert"
+  echo "  -k)   <SRC_KEY> - pre-existing server key"
+  echo "  -x)   <DATADIR> - local storage for client auth_info"
+  echo "FLAGS:"
+  echo "  -D)   set FABRIC_CA_DEBUG='true'"
+  echo "  -R)   set RESET='true' - delete DB, server certs, client certs"
+  echo "  -I)   set INIT='true'  - run fabric-ca server init"
+  echo "  -S)   set START='true' - start \$FABRIC_CA_INSTANCES number of servers"
+  echo "  -X)   set PROXY='true' - start haproxy for \$FABRIC_CA_INSTANCES of fabric-ca servers"
+  echo "  -K)   set KILL='true'  - kill all running fabric-ca instances and haproxy"
+  echo "  -L)   list all running fabric-ca instances"
+  echo "  -P)   Enable profiling port on the server"
+  echo " ?|h)  this help text"
+  echo ""
+  echo "Defaults: -d sqlite3 -n 1 -k ecdsa -l 256"
 }
 
 runPSQL() {
-   local cmd="$1"
-   local opts="$2"
-   local wrk_dir="$(pwd)"
-   cd /tmp
-   /usr/bin/psql "$opts" -U postgres -h localhost -c "$cmd"
-   local rc=$?
-   cd $wrk_dir
-   return $rc
+  local cmd="$1"
+  local opts="$2"
+  local wrk_dir="$(pwd)"
+  cd /tmp
+  /usr/bin/psql "$opts" -U postgres -h localhost -c "$cmd"
+  local rc=$?
+  cd $wrk_dir
+  return $rc
 }
 
-resetFabricCa(){
-   killAllFabricCas
-   rm -rf $DATADIR >/dev/null
-   test -f $(pwd)/${DBNAME}* && rm $(pwd)/${DBNAME}*
-   cd /tmp
+resetFabricCa() {
+  killAllFabricCas
+  rm -rf $DATADIR >/dev/null
+  test -f $(pwd)/${DBNAME}* && rm $(pwd)/${DBNAME}*
+  cd /tmp
 
-   # Base server and cluster servers
-   for i in "" $(seq ${CACOUNT:-0}); do
-      test -z $i && dbSuffix="" || dbSuffix="_ca$i"
-      mysql --host=localhost --user=root --password=mysql -e 'show tables' ${DBNAME}${dbSuffix} >/dev/null 2>&1
-         mysql --host=localhost --user=root --password=mysql -e "DROP DATABASE IF EXISTS ${DBNAME}${dbSuffix}" >/dev/null 2>&1
-      /usr/bin/dropdb "${DBNAME}${dbSuffix}" -U postgres -h localhost -w --if-exists 2>/dev/null
-   done
+  # Base server and cluster servers
+  for i in "" $(seq ${CACOUNT:-0}); do
+    test -z $i && dbSuffix="" || dbSuffix="_ca$i"
+    mysql --host=localhost --user=root --password=mysql -e 'show tables' ${DBNAME}${dbSuffix} >/dev/null 2>&1
+    mysql --host=localhost --user=root --password=mysql -e "DROP DATABASE IF EXISTS ${DBNAME}${dbSuffix}" >/dev/null 2>&1
+    /usr/bin/dropdb "${DBNAME}${dbSuffix}" -U postgres -h localhost -w --if-exists 2>/dev/null
+  done
 }
 
-listFabricCa(){
-   echo "Listening servers;"
-   local port=${USER_CA_PORT-$CA_DEFAULT_PORT}
-   local inst=0
-   while test $((inst)) -lt $FABRIC_CA_INSTANCES; do
-     lsof -n -i tcp:$((port+$inst))
-     inst=$((inst+1))
-   done
+listFabricCa() {
+  echo "Listening servers;"
+  local port=${USER_CA_PORT-$CA_DEFAULT_PORT}
+  local inst=0
+  while test $((inst)) -lt $FABRIC_CA_INSTANCES; do
+    lsof -n -i tcp:$((port + $inst))
+    inst=$((inst + 1))
+  done
 
-   # Base server and cluster servers
-   for i in "" $(seq ${CACOUNT:-0}); do
-      test -z $i && dbSuffix="" || dbSuffix="_ca$i"
+  # Base server and cluster servers
+  for i in "" $(seq ${CACOUNT:-0}); do
+    test -z $i && dbSuffix="" || dbSuffix="_ca$i"
+    echo ""
+    echo " ======================================"
+    echo " ========> Dumping ${DBNAME}${dbSuffix} Database"
+    echo " ======================================"
+    case $DRIVER in
+    mysql)
       echo ""
-      echo " ======================================"
-      echo " ========> Dumping ${DBNAME}${dbSuffix} Database"
-      echo " ======================================"
-      case $DRIVER in
-         mysql)
-            echo ""
-            echo "Users:"
-            mysql --host=localhost --user=root --password=mysql -e 'SELECT * FROM users;' ${DBNAME}${dbSuffix}
-            if $($FABRIC_CA_DEBUG); then
-               echo "Certificates:"
-               mysql --host=localhost --user=root --password=mysql -e 'SELECT * FROM certificates;' ${DBNAME}${dbSuffix}
-               echo "Affiliations:"
-               mysql --host=localhost --user=root --password=mysql -e 'SELECT * FROM affiliations;' ${DBNAME}${dbSuffix}
-            fi
-         ;;
-         postgres)
-            echo ""
-            runPSQL "\l ${DBNAME}${dbSuffix}" | sed 's/^/   /;1s/^ *//;1s/$/:/'
+      echo "Users:"
+      mysql --host=localhost --user=root --password=mysql -e 'SELECT * FROM users;' ${DBNAME}${dbSuffix}
+      if $($FABRIC_CA_DEBUG); then
+        echo "Certificates:"
+        mysql --host=localhost --user=root --password=mysql -e 'SELECT * FROM certificates;' ${DBNAME}${dbSuffix}
+        echo "Affiliations:"
+        mysql --host=localhost --user=root --password=mysql -e 'SELECT * FROM affiliations;' ${DBNAME}${dbSuffix}
+      fi
+      ;;
+    postgres)
+      echo ""
+      runPSQL "\l ${DBNAME}${dbSuffix}" | sed 's/^/   /;1s/^ *//;1s/$/:/'
 
-            echo "Users:"
-            runPSQL "SELECT * FROM USERS;" "--dbname=${DBNAME}${dbSuffix}" | sed 's/^/   /'
-            if $($FABRIC_CA_DEBUG); then
-               echo "Certificates::"
-               runPSQL "SELECT * FROM CERTIFICATES;" "--dbname=${DBNAME}${dbSuffix}" | sed 's/^/   /'
-               echo "Affiliations:"
-               runPSQL "SELECT * FROM AFFILIATIONS;" "--dbname=${DBNAME}${dbSuffix}" | sed 's/^/   /'
-            fi
-         ;;
-         sqlite3) test -z $i && DBDIR=$DATADIR || DBDIR="$DATADIR/ca/ca$i"
-                  sqlite3 "$DBDIR/$DBNAME" 'SELECT * FROM USERS ;;' | sed 's/^/   /'
-                  if $($FABRIC_CA_DEBUG); then
-                     sqlite3 "$DATASRC" 'SELECT * FROM CERTIFICATES;' | sed 's/^/   /'
-                     sqlite3 "$DATASRC" 'SELECT * FROM AFFILIATIONS;' | sed 's/^/   /'
-                  fi
-      esac
-   done
+      echo "Users:"
+      runPSQL "SELECT * FROM USERS;" "--dbname=${DBNAME}${dbSuffix}" | sed 's/^/   /'
+      if $($FABRIC_CA_DEBUG); then
+        echo "Certificates::"
+        runPSQL "SELECT * FROM CERTIFICATES;" "--dbname=${DBNAME}${dbSuffix}" | sed 's/^/   /'
+        echo "Affiliations:"
+        runPSQL "SELECT * FROM AFFILIATIONS;" "--dbname=${DBNAME}${dbSuffix}" | sed 's/^/   /'
+      fi
+      ;;
+    sqlite3)
+      test -z $i && DBDIR=$DATADIR || DBDIR="$DATADIR/ca/ca$i"
+      sqlite3 "$DBDIR/$DBNAME" 'SELECT * FROM USERS ;;' | sed 's/^/   /'
+      if $($FABRIC_CA_DEBUG); then
+        sqlite3 "$DATASRC" 'SELECT * FROM CERTIFICATES;' | sed 's/^/   /'
+        sqlite3 "$DATASRC" 'SELECT * FROM AFFILIATIONS;' | sed 's/^/   /'
+      fi
+      ;;
+    esac
+  done
 }
 
 function initFabricCa() {
-   test -f $FABRIC_CA_SERVEREXEC || ErrorExit "fabric-ca executable not found in src tree"
-   $FABRIC_CA_SERVEREXEC init -c $RUNCONFIG $PARENTURL $args
-   rc1=$?
-   if test $rc1 -eq 1; then
-      return $rc1
-   fi
-   echo "FABRIC_CA server initialized"
-   if $($FABRIC_CA_DEBUG); then
-      openssl x509 -in $DATADIR/$DST_CERT -noout -issuer -subject -serial \
-                   -dates -nameopt RFC2253| sed 's/^/   /'
-      openssl x509 -in $DATADIR/$DST_CERT -noout -text |
-         awk '
+  test -f $FABRIC_CA_SERVEREXEC || ErrorExit "fabric-ca executable not found in src tree"
+  $FABRIC_CA_SERVEREXEC init -c $RUNCONFIG $PARENTURL $args
+  rc1=$?
+  if test $rc1 -eq 1; then
+    return $rc1
+  fi
+  echo "FABRIC_CA server initialized"
+  if $($FABRIC_CA_DEBUG); then
+    openssl x509 -in $DATADIR/$DST_CERT -noout -issuer -subject -serial \
+      -dates -nameopt RFC2253 | sed 's/^/   /'
+    openssl x509 -in $DATADIR/$DST_CERT -noout -text |
+      awk '
             /Subject Alternative Name:/ {
                gsub(/^ */,"")
                printf $0"= "
                getline; gsub(/^ */,"")
                print
-            }'| sed 's/^/   /'
-      openssl x509 -in $DATADIR/$DST_CERT -noout -pubkey |
-         openssl $KEYTYPE -pubin -noout -text 2>/dev/null| sed 's/Private/Public/'
-      openssl $KEYTYPE -in $DATADIR/$DST_KEY -text 2>/dev/null
-   fi
+            }' | sed 's/^/   /'
+    openssl x509 -in $DATADIR/$DST_CERT -noout -pubkey |
+      openssl $KEYTYPE -pubin -noout -text 2>/dev/null | sed 's/Private/Public/'
+    openssl $KEYTYPE -in $DATADIR/$DST_KEY -text 2>/dev/null
+  fi
 }
 
-
 function startHaproxy() {
-   local inst=$1
-   local i=0
-   local proxypids=$(lsof -n -i tcp | awk '$1=="haproxy" && !($2 in a) {a[$2]=$2;print a[$2]}')
-   test -n "$proxypids" && kill $proxypids
-   local server_port=${USER_CA_PORT-$CA_DEFAULT_PORT}
-   case $TLS_ON in
-     "true")
-   haproxy -f  <(echo "global
+  local inst=$1
+  local i=0
+  local proxypids=$(lsof -n -i tcp | awk '$1=="haproxy" && !($2 in a) {a[$2]=$2;print a[$2]}')
+  test -n "$proxypids" && kill $proxypids
+  local server_port=${USER_CA_PORT-$CA_DEFAULT_PORT}
+  haproxy -f <(
+    echo "global
       log 127.0.0.1 local2
       daemon
 defaults
@@ -165,20 +165,20 @@ frontend haproxy
 
 backend fabric-cas
    mode tcp
-   balance roundrobin";
+   balance roundrobin"
 
-   # For each requested instance passed to startHaproxy
-   # (which is determined by the -n option passed to the
-   # main script) create a backend server in haproxy config
-   # Each server binds to a unique port on INADDR_ANY
-   while test $((i)) -lt $inst; do
-      echo "      server server$i  localhost:$((server_port+$i))"
-      i=$((i+1))
-   done
-   i=0
+    # For each requested instance passed to startHaproxy
+    # (which is determined by the -n option passed to the
+    # main script) create a backend server in haproxy config
+    # Each server binds to a unique port on INADDR_ANY
+    while test $((i)) -lt $inst; do
+      echo "      server server$i  localhost:$((server_port + $i))"
+      i=$((i + 1))
+    done
+    i=0
 
-if test -n "$FABRIC_CA_SERVER_PROFILE_PORT" ; then
-echo "
+    if test -n "$FABRIC_CA_SERVER_PROFILE_PORT"; then
+      echo "
 frontend haproxy-profile
       bind *:8889
       mode http
@@ -188,16 +188,16 @@ frontend haproxy-profile
 backend fabric-ca-profile
       mode http
       http-request set-header X-Forwarded-Port %[dst_port]
-      balance roundrobin";
-   while test $((i)) -lt $inst; do
-      echo "      server server$i  localhost:$((FABRIC_CA_SERVER_PROFILE_PORT+$i))"
-      i=$((i+1))
-   done
-   i=0
-fi
+      balance roundrobin"
+      while test $((i)) -lt $inst; do
+        echo "      server server$i  localhost:$((FABRIC_CA_SERVER_PROFILE_PORT + $i))"
+        i=$((i + 1))
+      done
+      i=0
+    fi
 
-if test -n "$FABRIC_CA_INTERMEDIATE_SERVER_PORT" ; then
-echo "
+    if test -n "$FABRIC_CA_INTERMEDIATE_SERVER_PORT"; then
+      echo "
 frontend haproxy-intcas
       bind *:$INTERMEDIATE_PROXY_PORT
       mode tcp
@@ -206,173 +206,95 @@ frontend haproxy-intcas
 
 backend fabric-intcas
    mode tcp
-   balance roundrobin";
+   balance roundrobin"
 
-   while test $((i)) -lt $inst; do
-      echo "      server intserver$i  localhost:$((INTERMEDIATE_CA_DEFAULT_PORT+$i))"
-      i=$((i+1))
-   done
-   i=0
-fi
-)
-   ;;
-   *)
-   haproxy -f  <(echo "global
-      log 127.0.0.1 local2
-      daemon
-defaults
-      log     global
-      mode http
-      option  httplog
-      option  dontlognull
-      maxconn 4096
-      timeout connect 30000
-      timeout client 300000
-      timeout server 300000
-      option forwardfor
+      while test $((i)) -lt $inst; do
+        echo "      server intserver$i  localhost:$((INTERMEDIATE_CA_DEFAULT_PORT + $i))"
+        i=$((i + 1))
+      done
+      i=0
+    fi
+  )
 
-listen stats
-      bind *:10888
-      stats enable
-      stats uri /
-      stats enable
-
-frontend haproxy
-      bind *:$PROXY_PORT
-      mode http
-      option tcplog
-      default_backend fabric-cas
-
-backend fabric-cas
-      mode http
-      http-request set-header X-Forwarded-Port %[dst_port]
-      balance roundrobin";
-   while test $((i)) -lt $inst; do
-      echo "      server server$i  localhost:$((server_port+$i))"
-      i=$((i+1))
-   done
-   i=0
-
-if test -n "$FABRIC_CA_SERVER_PROFILE_PORT" ; then
-echo "
-frontend haproxy-profile
-      bind *:8889
-      mode http
-      option tcplog
-      default_backend fabric-ca-profile
-
-backend fabric-ca-profile
-      mode http
-      http-request set-header X-Forwarded-Port %[dst_port]
-      balance roundrobin";
-   while test $((i)) -lt $inst; do
-      echo "      server server$i  localhost:$((FABRIC_CA_SERVER_PROFILE_PORT+$i))"
-      i=$((i+1))
-   done
-   i=0
-fi
-
-if test -n "$FABRIC_CA_INTERMEDIATE_SERVER_PORT" ; then
-echo "
-frontend haproxy-intcas
-      bind *:$INTERMEDIATE_PROXY_PORT
-      mode http
-      option tcplog
-      default_backend fabric-intcas
-
-backend fabric-intcas
-      mode http
-      http-request set-header X-Forwarded-Port %[dst_port]
-      balance roundrobin";
-
-   while test $((i)) -lt $inst; do
-      echo "      server intserver$i  localhost:$((INTERMEDIATE_CA_DEFAULT_PORT+$i))"
-      i=$((i+1))
-   done
-   i=0
-fi
-)
-   ;;
-   esac
 }
 
 function startFabricCa() {
-   local inst=$1
-   local start=$SECONDS
-   local timeout="$TIMEOUT"
-   local now=0
-   local server_addr=0.0.0.0
-   local polladdr=$server_addr
-   local port=${USER_CA_PORT-$CA_DEFAULT_PORT}
-   port=$((port+$inst))
-   # if not explcitly set, use default
-   test -n "${port}" && local server_port="--port $port" || local server_port=""
-   test -n "${CACOUNT}" && local cacount="--cacount ${CACOUNT}"
+  local inst=$1
+  local start=$SECONDS
+  local timeout="$TIMEOUT"
+  local now=0
+  local server_addr=0.0.0.0
+  local polladdr=$server_addr
+  local port=${USER_CA_PORT-$CA_DEFAULT_PORT}
+  port=$((port + $inst))
+  # if not explcitly set, use default
+  test -n "${port}" && local server_port="--port $port" || local server_port=""
+  test -n "${CACOUNT}" && local cacount="--cacount ${CACOUNT}"
 
-   if test -n "$FABRIC_CA_SERVER_PROFILE_PORT" ; then
-      local profile_port=$((FABRIC_CA_SERVER_PROFILE_PORT+$inst))
-      FABRIC_CA_SERVER_PROFILE_PORT=$profile_port $FABRIC_CA_SERVEREXEC start --address $server_addr $server_port --ca.certfile $DST_CERT \
-                     --ca.keyfile $DST_KEY --config $RUNCONFIG $PARENTURL 2>&1 &
-   else
-#      $FABRIC_CA_SERVEREXEC start --address $server_addr $server_port --ca.certfile $DST_CERT \
-#                     --ca.keyfile $DST_KEY $cacount --config $RUNCONFIG $args > $DATADIR/server${port}.log 2>&1 &
-      $FABRIC_CA_SERVEREXEC start --address $server_addr $server_port --ca.certfile $DST_CERT \
-                     --ca.keyfile $DST_KEY $cacount --config $RUNCONFIG $args 2>&1 &
-   fi
+  if test -n "$FABRIC_CA_SERVER_PROFILE_PORT"; then
+    local profile_port=$((FABRIC_CA_SERVER_PROFILE_PORT + $inst))
+    FABRIC_CA_SERVER_PROFILE_PORT=$profile_port $FABRIC_CA_SERVEREXEC start --address $server_addr $server_port --ca.certfile $DST_CERT \
+      --ca.keyfile $DST_KEY --config $RUNCONFIG $PARENTURL 2>&1 &
+  else
+    #      $FABRIC_CA_SERVEREXEC start --address $server_addr $server_port --ca.certfile $DST_CERT \
+    #                     --ca.keyfile $DST_KEY $cacount --config $RUNCONFIG $args > $DATADIR/server${port}.log 2>&1 &
+    $FABRIC_CA_SERVEREXEC start --address $server_addr $server_port --ca.certfile $DST_CERT \
+      --ca.keyfile $DST_KEY $cacount --config $RUNCONFIG $args 2>&1 &
+  fi
 
-   printf "FABRIC_CA server on $server_addr:$port "
-   test "$server_addr" = "0.0.0.0" && polladdr="127.0.0.1"
-   pollFabricCa "" "$server_addr" "$port" "" "$TIMEOUT"
-   if test "$?" -eq 0; then
-      echo " STARTED"
-   else
-      RC=$((RC+1))
-      echo " FAILED"
-   fi
+  printf "FABRIC_CA server on $server_addr:$port "
+  test "$server_addr" = "0.0.0.0" && polladdr="127.0.0.1"
+  pollFabricCa "" "$server_addr" "$port" "" "$TIMEOUT"
+  if test "$?" -eq 0; then
+    echo " STARTED"
+  else
+    RC=$((RC + 1))
+    echo " FAILED"
+  fi
 }
 
 function killAllFabricCas() {
-   local fabric_capids=$(ps ax | awk '$5~/fabric-ca/ {print $1}')
-   local proxypids=$(lsof -n -i tcp | awk '$1=="haproxy" && !($2 in a) {a[$2]=$2;print a[$2]}')
-   test -n "$fabric_capids" && kill $fabric_capids
-   test -n "$proxypids" && kill $proxypids
+  local fabric_capids=$(ps ax | awk '$5~/fabric-ca/ {print $1}')
+  local proxypids=$(lsof -n -i tcp | awk '$1=="haproxy" && !($2 in a) {a[$2]=$2;print a[$2]}')
+  test -n "$fabric_capids" && kill $fabric_capids
+  test -n "$proxypids" && kill $proxypids
 }
 
 while getopts "\?hRCISKXLDTAPNad:t:l:n:c:k:x:g:m:p:r:o:u:U:" option; do
   case "$option" in
-     a)   LDAP_ENABLE="true" ;;
-     o)   TIMEOUT="$OPTARG" ;;
-     u)   CACOUNT="$OPTARG" ;;
-     d)   DRIVER="$OPTARG" ;;
-     r)   USER_CA_PORT="$OPTARG" ;;
-     p)   HTTP_PORT="$OPTARG" ;;
-     n)   FABRIC_CA_INSTANCES="$OPTARG" ;;
-     t)   KEYTYPE=$(tolower $OPTARG);;
-     l)   KEYLEN="$OPTARG" ;;
-     c)   SRC_CERT="$OPTARG";;
-     k)   SRC_KEY="$OPTARG" ;;
-     x)   CA_CFG_PATH="$OPTARG" ;;
-     m)   MAXENROLL="$OPTARG" ;;
-     g)   SERVERCONFIG="$OPTARG" ;;
-     U)   PARENTURL="$OPTARG" ;;
-     D)   export FABRIC_CA_DEBUG='true' ;;
-     A)   AUTH="false" ;;
-     R)   RESET="true"  ;;
-     I)   INIT="true" ;;
-     S)   START="true" ;;
-     X)   PROXY="true" ;;
-     K)   KILL="true" ;;
-     L)   LIST="true" ;;
-     T)   TLS_ON="true" ;;
-     P)   export FABRIC_CA_SERVER_PROFILE_PORT=$PROFILING_PORT ;;
-     N)   export FABRIC_CA_INTERMEDIATE_SERVER_PORT=$INTERMEDIATE_CA_DEFAULT_PORT;;
-   \?|h)  usage
-          exit 1
-          ;;
+  a) LDAP_ENABLE="true" ;;
+  o) TIMEOUT="$OPTARG" ;;
+  u) CACOUNT="$OPTARG" ;;
+  d) DRIVER="$OPTARG" ;;
+  r) USER_CA_PORT="$OPTARG" ;;
+  p) HTTP_PORT="$OPTARG" ;;
+  n) FABRIC_CA_INSTANCES="$OPTARG" ;;
+  t) KEYTYPE=$(tolower $OPTARG) ;;
+  l) KEYLEN="$OPTARG" ;;
+  c) SRC_CERT="$OPTARG" ;;
+  k) SRC_KEY="$OPTARG" ;;
+  x) CA_CFG_PATH="$OPTARG" ;;
+  m) MAXENROLL="$OPTARG" ;;
+  g) SERVERCONFIG="$OPTARG" ;;
+  U) PARENTURL="$OPTARG" ;;
+  D) export FABRIC_CA_DEBUG='true' ;;
+  A) AUTH="false" ;;
+  R) RESET="true" ;;
+  I) INIT="true" ;;
+  S) START="true" ;;
+  X) PROXY="true" ;;
+  K) KILL="true" ;;
+  L) LIST="true" ;;
+  P) export FABRIC_CA_SERVER_PROFILE_PORT=$PROFILING_PORT ;;
+  N) export FABRIC_CA_INTERMEDIATE_SERVER_PORT=$INTERMEDIATE_CA_DEFAULT_PORT ;;
+  \? | h)
+    usage
+    exit 1
+    ;;
   esac
 done
 
-shift $((OPTIND-1))
+shift $((OPTIND - 1))
 args=$@
 : ${LDAP_ENABLE:="false"}
 : ${TIMEOUT:=$DEFAULT_TIMEOUT}
@@ -400,21 +322,6 @@ test -n "$PARENTURL" && PARENTURL="-u $PARENTURL"
 : ${DATADIR:="$CA_CFG_PATH"}
 export CA_CFG_PATH
 
-# regarding tls:
-#    honor the command-line setting to turn on TLS
-#      else honor the envvar
-#        else (default) turn off tls
-sslmode=disable
-if test -n "$TLS_ON"; then
-   TLS_DISABLE='false'; LDAP_PORT=636; LDAP_PROTO="ldaps://";sslmode="require";mysqlTls='&tls=custom'
-else
-   case "$FABRIC_TLS" in
-      true) TLS_DISABLE='false';TLS_ON='true'; LDAP_PORT=636; LDAP_PROTO="ldaps://";sslmode="require";mysqlTls='&tls=custom' ;;
-     false) TLS_DISABLE='true' ;TLS_ON='false' ;;
-         *) TLS_DISABLE='true' ;TLS_ON='false' ;;
-   esac
-fi
-
 test -d $DATADIR || mkdir -p $DATADIR
 DST_KEY="fabric-ca-key.pem"
 DST_CERT="fabric-ca-cert.pem"
@@ -423,32 +330,32 @@ test -n "$SRC_KEY" && cp "$SRC_KEY" $DATADIR/$DST_KEY
 RUNCONFIG="$DATADIR/$DEFAULT_RUN_CONFIG_FILE_NAME"
 
 case $DRIVER in
-   postgres) DATASRC="dbname=$DBNAME host=127.0.0.1 port=$POSTGRES_PORT user=postgres password=postgres sslmode=$sslmode" ;;
-   sqlite3)  DATASRC="$DBNAME" ;;
-   mysql)    DATASRC="root:mysql@tcp(localhost:$MYSQL_PORT)/$DBNAME?parseTime=true$mysqlTls" ;;
+postgres) DATASRC="dbname=$DBNAME host=127.0.0.1 port=$POSTGRES_PORT user=postgres password=postgres" ;;
+sqlite3) DATASRC="$DBNAME" ;;
+mysql) DATASRC="root:mysql@tcp(localhost:$MYSQL_PORT)/$DBNAME?parseTime=true" ;;
 esac
 
-$($LIST)  && listFabricCa
+$($LIST) && listFabricCa
 $($RESET) && resetFabricCa
-$($KILL)  && killAllFabricCas
+$($KILL) && killAllFabricCas
 $($PROXY) && startHaproxy $FABRIC_CA_INSTANCES
 
-$( $INIT -o $START ) && genRunconfig "$RUNCONFIG" "$DRIVER" "$DATASRC" "$DST_CERT" "$DST_KEY" "$MAXENROLL"
+$($INIT -o $START) && genRunconfig "$RUNCONFIG" "$DRIVER" "$DATASRC" "$DST_CERT" "$DST_KEY" "$MAXENROLL"
 test -n "$SERVERCONFIG" && cp "$SERVERCONFIG" "$RUNCONFIG"
 
 if $($INIT); then
-   initFabricCa
-   rc2=$?
-   if test $rc2 -eq 1; then
-       exit $rc2
-   fi
+  initFabricCa
+  rc2=$?
+  if test $rc2 -eq 1; then
+    exit $rc2
+  fi
 fi
 
 if $($START); then
-   inst=0
-   while test $((inst)) -lt $FABRIC_CA_INSTANCES; do
-      startFabricCa $inst
-      inst=$((inst+1))
-   done
+  inst=0
+  while test $((inst)) -lt $FABRIC_CA_INSTANCES; do
+    startFabricCa $inst
+    inst=$((inst + 1))
+  done
 fi
 exit $RC

--- a/scripts/fvt/fabric-ca_utils
+++ b/scripts/fvt/fabric-ca_utils
@@ -10,8 +10,8 @@ export FABRIC_CA_SERVEREXEC="/usr/local/bin/fabric-ca-server"
 export TESTDATA="$FABRIC_CA/testdata"
 export SCRIPTDIR="$FABRIC_CA/scripts/fvt"
 export MYSQL_PORT="3306"
-export LDAP_PORT="389"
-export LDAP_PROTO="ldap://"
+export LDAP_PORT="636"
+export LDAP_PROTO="ldaps://"
 export LDAP_TLS_PROTO="ldaps://"
 export POSTGRES_PORT="5432"
 export PGPASSWORD='postgres'
@@ -25,6 +25,8 @@ export TLS_SERVERCERT="$FABRIC_CA_DATA/FabricTlsServerEEcert.pem"
 export TLS_SERVERKEY="$FABRIC_CA_DATA/FabricTlsServerEEkey.pem"
 export TLS_CLIENTCERT="$FABRIC_CA_DATA/FabricTlsClientEEcert.pem"
 export TLS_CLIENTKEY="$FABRIC_CA_DATA/FabricTlsClientEEkey.pem"
+export TLSOPT="--tls.certfiles $TLS_ROOTCERT"
+export INTTLSOPT="--intermediate.tls.certfiles $TLS_ROOTCERT"
 export CA_HOST_ADDRESS="localhost"
 export PROXY_PORT="7054"
 export CA_DEFAULT_PORT="1${PROXY_PORT}"
@@ -41,7 +43,7 @@ export LDAPAUTH="-D "cn=$LDAPUSER,dc=example,dc=com" -w $LDAPPASWD"
 export LDAPBASE="-b "dc=example,dc=com""
 export LDAPUSERBASE="-b ou=users,ou=fabric,dc=hyperledeger,dc=example,dc=com"
 export DEFAULT_RUN_CONFIG_FILE_NAME="runFabricCaFvt.yaml"
-
+export PROTO="https://"
 DATE='date +%Y-%m-%d'
 TIME='date +%I:%M:%S%p'
 
@@ -146,22 +148,6 @@ runPSQL() {
    local rc=$?
    cd $wrk_dir
    return $rc
-}
-
-setTLS() {
-   PROTO="http://"
-   TLSOPT=""
-   # if not set, default to OFF
-   if test -n "$FABRIC_TLS"; then
-     # otherwise, set TLS-related stuff
-     if $($FABRIC_TLS); then
-        PROTO="https://"
-        LDAP_PROTO="ldaps://"
-        LDAP_PORT=636
-        TLSOPT="--tls.certfiles $TLS_ROOTCERT"
-        INTTLSOPT="--intermediate.tls.certfiles $TLS_ROOTCERT"
-     fi
-   fi
 }
 
 ErrorMsg() {
@@ -451,8 +437,6 @@ enroll() {
    test -d "$FABRIC_CA_ENROLLMENT_DIR" || mkdir -p "$FABRIC_CA_ENROLLMENT_DIR"
    ENROLLCONFIG="$FABRIC_CA_ENROLLMENT_DIR/enroll.yaml"
 
-   # Determines the PROTO and TLSOPT values based on FABRIC_TLS setting
-   setTLS
    $FABRIC_CA_CLIENTEXEC enroll -u "${PROTO}${username}:${userpswd}@${CA_HOST_ADDRESS}:$PROXY_PORT" $TLSOPT \
                          -c $ENROLLCONFIG $ATTRS \
                          --csr.hosts "$username@fab-client.raleigh.ibm.com" \
@@ -486,7 +470,6 @@ reenroll() {
    test -d "$FABRIC_CA_CLIENT_HOME" || mkdir -p "$FABRIC_CA_CLIENT_HOME"
    ENROLLCONFIG="$FABRIC_CA_CLIENT_HOME/enroll.yaml"
    export FABRIC_CA_CLIENT_HOME
-   setTLS
    $FABRIC_CA_CLIENTEXEC reenroll -u $PROTO${CA_HOST_ADDRESS}:$PROXY_PORT $TLSOPT -c $ENROLLCONFIG
    RC=$?
    $($FABRIC_CA_DEBUG) && printAuth $FABRIC_CA_CERT_FILE $FABRIC_CA_KEY_FILE
@@ -512,7 +495,6 @@ register() {
    : ${FABRIC_CA_CLIENT_HOME:="$CA_CFG_PATH/$REGISTRAR"}
 
    export FABRIC_CA_ENROLLMENT_DIR
-   setTLS
    $FABRIC_CA_CLIENTEXEC register -d -u "$PROTO${CA_HOST_ADDRESS}:$PROXY_PORT" $TLSOPT \
                            --id.name "$USERNAME" \
                            --id.type "$USERTYPE" \
@@ -532,11 +514,9 @@ function genRunconfig() {
    local serverKey="$5"
    local maxEnroll="$6"
    local version="$7"
-   : ${FABRIC_TLS:='false'}
    : ${FABRIC_CA_DEBUG:='false'}
    local registry=""
    local converters=""
-   setTLS
 
    case ${version:-"yaml"} in
       json) if ! $($LDAP_ENABLE); then registry="
@@ -656,18 +636,10 @@ cat > $runconfig <<EOF
    "debug": "$FABRIC_CA_DEBUG",
    "db": {
       "type": "$driver",
-      "datasource": "$datasrc",
-       "tls": {
-          "enabled": "$TLS_ON",
-          "certfiles": [ "$TLS_ROOTCERT", $TLS_RACERT, $TLS_SUBCACERT ],
-          "client": {
-             "certfile": "$TLS_CLIENTCERT",
-             "keyfile": "$TLS_CLIENTKEY"
-          }
-       }
+      "datasource": "$datasrc"
    },
    "tls": {
-      "enabled": "$TLS_ON",
+      "enabled": true,
       "certfile": "$TLS_SERVERCERT",
       "keyfile": "$TLS_SERVERKEY"
    },
@@ -886,15 +858,8 @@ debug: $FABRIC_CA_DEBUG
 db:
   type: $driver
   datasource: $datasrc
-  tls:
-     enabled: $TLS_ON
-     certfiles:
-       - $TLS_ROOTCERT
-     client:
-       certfile: $TLS_CLIENTCERT
-       keyfile: $TLS_CLIENTKEY
 tls:
-  enabled: $TLS_ON
+  enabled: true
   certfile: $TLS_SERVERCERT
   keyfile: $TLS_SERVERKEY
 ca:

--- a/scripts/fvt/idemix_test.sh
+++ b/scripts/fvt/idemix_test.sh
@@ -114,7 +114,6 @@ for driver in postgres mysql; do
     $SCRIPTDIR/fabric-ca_setup.sh -I -S -X -D -d $driver 2>&1 | tee /tmp/serverlog.txt &
     pollFabricCa "" "" $CA_DEFAULT_PORT
 
-    setTLS
     ###### Get Idemix Public Key ######
     getCAInfo
 

--- a/scripts/fvt/ident_modify_test.sh
+++ b/scripts/fvt/ident_modify_test.sh
@@ -456,7 +456,6 @@ sed -i '/name: admin$/,/hf.Registrar.DelegateRoles:/s/hf.Registrar.Roles:.*/hf.R
 $SCRIPTDIR/fabric-ca_setup.sh -d mysql -S -X -n1 -D -x $TESTDIR -- \
                  --cfg.identities.allowremove > $TESTDIR/server.log 2>&1
 
-setTLS
 URI="-u ${PROTO}@$CA_HOST_ADDRESS:$PROXY_PORT $TLSOPT"
 
 enroll

--- a/scripts/fvt/multica_test.sh
+++ b/scripts/fvt/multica_test.sh
@@ -12,7 +12,6 @@ FABRIC_CA="$GOPATH/src/github.com/hyperledger/fabric-ca"
 SCRIPTDIR="$FABRIC_CA/scripts/fvt"
 TESTDATA="$FABRIC_CA/testdata"
 . $SCRIPTDIR/fabric-ca_utils
-PROTO="http://"
 TLSDIR="$TESTDATA"
 NUMINTCAS=4
 MAXENROLL=$((2*NUMINTCAS))
@@ -123,13 +122,6 @@ function resetDB() {
   fi
 }
 
-#function setTLS() {
-#: ${FABRIC_TLS:="false"}
-#if $($FABRIC_TLS); then
-#   PROTO="https://"
-#fi
-#}
-
 ### Start Test ###
 for driver in postgres mysql; do
 
@@ -147,8 +139,6 @@ for driver in postgres mysql; do
    $SCRIPTDIR/fabric-ca_setup.sh -R -x $TDIR/ca0 -D -d $driver
    rm -rf $TDIR
 
-   # if ENV FABRIC_TLS=true, use TLS
-   setTLS
    resetDB $driver
 
    createRootCA || ErrorExit "Failed to create root CA"

--- a/scripts/fvt/passwordsInLog_test.sh
+++ b/scripts/fvt/passwordsInLog_test.sh
@@ -127,7 +127,6 @@ PSWD=thisIs_aLongUniquePasswordWith_aMinisculePossibilityOfBeingDuplicated
 
 $SCRIPTDIR/fabric-ca_setup.sh -R
 mkdir -p $TESTDIR
-setTLS
 testBootstrap
 testCaRegistry
 testExternalServers

--- a/scripts/fvt/postgres_test.sh
+++ b/scripts/fvt/postgres_test.sh
@@ -41,28 +41,16 @@ function resetDB {
 }
 
 function genConfig {
-    postgresTls='sslmode=disable'
-   case "$FABRIC_TLS" in
-      true) postgresTls='sslmode=require' ;;
-   esac
-
    mkdir -p $FABRIC_CA_SERVER_HOME
    cat > $PGSQLSERVERCONFIG <<EOF
 debug: true
 
 db:
   type: postgres
-  datasource: host=localhost port=$POSTGRES_PORT user=testuser password=testuserpw dbname=fabric_ca $postgresTls
-  tls:
-     enabled: $FABRIC_TLS
-     certfiles:
-       - $TLS_ROOTCERT
-     client:
-       certfile: $TLS_CLIENTCERT
-       keyfile: $TLS_CLIENTKEY
+  datasource: host=localhost port=$POSTGRES_PORT user=testuser password=testuserpw dbname=fabric_ca
 
 tls:
-  enabled: $FABRIC_TLS
+  enabled: true
   certfile: $TLS_SERVERCERT
   keyfile: $TLS_SERVERKEY
 

--- a/scripts/fvt/reenroll.sh
+++ b/scripts/fvt/reenroll.sh
@@ -14,7 +14,7 @@ HOST="http://localhost:$PROXY_PORT"
 RUNCONFIG="$TESTDATA/postgres.json"
 INITCONFIG="$TESTDATA/csr_ecdsa256.json"
 RC=0
-$($FABRIC_TLS) && HOST="https://localhost:$PROXY_PORT"
+HOST="https://localhost:$PROXY_PORT"
 
 . $SCRIPTDIR/fabric-ca_utils
 

--- a/scripts/fvt/reenroll_test.sh
+++ b/scripts/fvt/reenroll_test.sh
@@ -103,16 +103,6 @@ for driver in sqlite3 postgres mysql; do
       test $? -ne 0 && ErrorMsg "Failed to reenroll user${i}"
    done
 
-   if ! $(${FABRIC_TLS:-false}); then
-      nums=$((NUM_SERVERS-1))
-      for s in $(eval echo {0..$nums}); do
-         curl -s http://${HOST}/ | awk -v s="server${s}" '$0~s'|html2text|grep HTTP
-         verifyServerTraffic $HOST server${s} $EXPECTED_DISTRIBUTION
-         test $? -ne 0 && ErrorMsg "Distributed traffic to server FAILED"
-         sleep .1
-      done
-   fi
-
    keyStore="$CA_CFG_PATH/user1/$MSP_KEY_DIR"
    certStore="$CA_CFG_PATH/user1/$MSP_CERT_DIR"
    for cert in EXPIRED UNRIPE UNSUPPORTED; do

--- a/scripts/fvt/register.sh
+++ b/scripts/fvt/register.sh
@@ -11,7 +11,7 @@ TESTDATA="$FABRIC_CA/testdata"
 SCRIPTDIR="$FABRIC_CA/scripts/fvt"
 HOST="http://localhost:$PROXY_PORT"
 RC=0
-$($FABRIC_TLS) && HOST="https://localhost:$PROXY_PORT"
+HOST="https://localhost:$PROXY_PORT"
 . $SCRIPTDIR/fabric-ca_utils
 
 while getopts "u:t:g:a:x:" option; do

--- a/scripts/fvt/reregister_test.sh
+++ b/scripts/fvt/reregister_test.sh
@@ -64,18 +64,6 @@ for driver in sqlite3 postgres mysql; do
       test $? -eq 0 && ErrorMsg "Duplicate registration of $USERNAME"
    done
 
-   # all servers should register = number of successful requests
-   # but...it's only available when tls is disabled
-   if ! $(${FABRIC_TLS:-false}); then
-      nums=$((NUM_SERVERS-1))
-      for s in $(eval echo {0..$nums}); do
-         curl -s http://${HOST}/ | awk -v s="server${s}" '$0~s'|html2text|grep HTTP
-         verifyServerTraffic $HOST server${s} 0 0 "HTTP 4xx" gt
-         test $? -eq 0 || ErrorMsg "verifyServerTraffic failed"
-         sleep .1
-      done
-   fi
-
    $SCRIPTDIR/fabric-ca_setup.sh -L -d $driver
 done
 $SCRIPTDIR/fabric-ca_setup.sh -R -x $CA_CFG_PATH -d $driver

--- a/scripts/fvt/revoke_test.sh
+++ b/scripts/fvt/revoke_test.sh
@@ -18,7 +18,6 @@ PSWDS=("adminpw" "adminpw2" "pass" "user1" "user2" "user3" )
 HTTP_PORT="3755"
 
 . $SCRIPTDIR/fabric-ca_utils
-setTLS
 # FIXME should not require user:pass
 URI="${PROTO}user:pass@localhost:$PROXY_PORT"
 

--- a/scripts/fvt/roundrobin_test.sh
+++ b/scripts/fvt/roundrobin_test.sh
@@ -35,17 +35,6 @@ for driver in sqlite3 mysql postgres ; do
    $SCRIPTDIR/registerAndEnroll.sh -u "${USERS[*]}"
    test $? -ne 0 && ErrorMsg "registerAndEnroll failed"
    reenroll admin
-   if ! $(${FABRIC_TLS:-false}); then
-      nums=$((NUM_SERVERS-1))
-      for s in $(eval echo {0..$nums}); do
-         curl -s http://$HOST/ |
-            awk -v s="server${s}\"" '$0~s'|
-               html2text |
-                  egrep "HTTP|server${s}"
-         verifyServerTraffic $HOST server${s} $EXPECTED_DISTRIBUTION
-         test $? -ne 0 && ErrorMsg "verifyServerTraffic failed"
-      done
-   fi
    $SCRIPTDIR/fabric-ca_setup.sh -L
 done
 $SCRIPTDIR/fabric-ca_setup.sh -R -x $CA_CFG_PATH

--- a/scripts/run_fvt_tests
+++ b/scripts/run_fvt_tests
@@ -11,27 +11,28 @@ export RESULTLOG="/tmp/fvt-test.results"
 export STARTIME=$SECONDS
 export PATH=$PATH:$GOPATH/bin
 export RC=0
-export FABRIC_TLS
-> $RESULTLOG
+>$RESULTLOG
 
 function runTests() {
-   echo "Running fvt tests ..."
-   echo ""
-   tests="$(find $SCRIPTDIR -maxdepth 1 -name "*test.*sh"| sort)"
+  echo "Running fvt tests ..."
+  echo ""
 
-   for FABRIC_TLS in "true" "false"; do
-      for cmd in $tests; do
-        export TESTCASE="${cmd##*/}-TLS-${FABRIC_TLS}"
-        echo "*******************"  | tee -a $RESULTLOG 2>&1
-        printf " Running $TESTCASE " |tee -a $RESULTLOG 2>&1
-        ${cmd} >> $RESULTLOG 2>&1
-        rc=$?
-        test $rc -eq 0 && echo PASSED || echo FAILED
-        test $rc -ne 0 && awk -v b=$TESTCASE -v e="test ended." '$0~b,$0~e' $RESULTLOG
-        RC=$((RC+$rc))
-        $SCRIPTDIR/fabric-ca_setup.sh -R >/dev/null 2>&1
-      done
-   done
+  tests="$(find $SCRIPTDIR -maxdepth 1 -name "*test.*sh"| sort)"
+  for cmd in $tests; do
+    runTest "${cmd}"
+  done
+}
+
+function runTest() {
+  export TESTCASE="${1##*/}"
+  echo "*******************" | tee -a $RESULTLOG 2>&1
+  printf " Running $TESTCASE " | tee -a $RESULTLOG 2>&1
+  ${1} >>$RESULTLOG 2>&1
+  rc=$?
+  test $rc -eq 0 && echo PASSED || echo FAILED
+  test $rc -ne 0 && awk -v b=$TESTCASE -v e="test ended." '$0~b,$0~e' $RESULTLOG
+  RC=$((RC + $rc))
+  $SCRIPTDIR/fabric-ca_setup.sh -R >/dev/null 2>&1
 }
 
 TimeStamp | tee $RESULTLOG


### PR DESCRIPTION
Today we run the entire FVT test suite once with SSL enabled and once with it disabled for connections to the Fabric CA Server and for connections from the CA to the CA's DB. This change will run all tests with TLS enabled for the CA server, disabled for the DB connection.

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>