### PR TITLE
Fix URL to contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,14 @@
 # Contributions Welcome!
 
-This repository is part of the Fabric project.
-Please consult [Fabric's CONTRIBUTING documentation](https://github.com/hyperledger/fabric/blob/master/docs/CONTRIBUTING.md) for information on how to contribute to this repository.
+This repository is part of the 
+[Fabric project](https://wiki.hyperledger.org/display/fabric/Hyperledger+Fabric).
+Please consult
+[Fabric's Contributuon Guide](https://hyperledger-fabric.readthedocs.io/en/latest/CONTRIBUTING.html)
+for information on how to contribute to this repository.
 
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+  <img alt="Creative Commons License" style="border-width:0" 
+    src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
+    <br />This work is licensed under a <a rel="license" 
+      href="http://creativecommons.org/licenses/by/4.0/">
+        Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
The link to the contributions guide was broken.

This PR is pioneering a process of allowing submission
of a bug fix without a corresponding JIRA issue.

Signed-off-by: Christopher Ferris <chrisfer@us.ibm.com>