### PR TITLE
[FABC-865] Fix setting TLS files by cert/key.file

### DIFF
--- a/cmd/fabric-ca-server/config.go
+++ b/cmd/fabric-ca-server/config.go
@@ -576,6 +576,28 @@ func (s *ServerCmd) configInit() (err error) {
 		return err
 	}
 
+	// Read operations tls files
+	if s.myViper.GetBool("operations.tls.enabled") {
+		cf := s.myViper.GetString("operations.tls.cert.file")
+		if !filepath.IsAbs(cf) {
+			cf = filepath.Join(s.homeDirectory, cf)
+		}
+		if util.FileExists(cf) {
+			s.cfg.Operations.TLS.CertFile = cf
+		} else {
+			return errors.Errorf("failed to read certificate file: %s", cf)
+		}
+		kf := s.myViper.GetString("operations.tls.key.file")
+		if !filepath.IsAbs(kf) {
+			kf = filepath.Join(s.homeDirectory, kf)
+		}
+		if util.FileExists(kf) {
+			s.cfg.Operations.TLS.KeyFile = kf
+		} else {
+			return errors.Errorf("failed to read key file: %s", kf)
+		}
+	}
+
 	// The pathlength field controls how deep the CA hierarchy when requesting
 	// certificates. If it is explicitly set to 0, set the PathLenZero field to
 	// true as CFSSL expects.


### PR DESCRIPTION
This CR allows operations.tls.{cert, key}.file key to set operations TLS certificate and key file.

It is set operation TLS files to operations.tls.{cert, key}.file key in config. However, operations TLS struct accepts operations.tls.{certfile, keyfile}. As a result, it doesn't not working even if it was set in operations.tls.{cert, key}.file.

(cherry picked from commit df3294560368bf120cb8373a9e72b949593b5cc0)