### PR TITLE
[FABC-882] Remove Fabric BaseImage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,6 @@ BASE_VERSION = 2.0.0
 PREV_VERSION = 2.0.0-alpha
 IS_RELEASE = false
 
-BASEIMAGE_RELEASE = 0.4.16
-
 ARCH=$(shell go env GOARCH)
 MARCH=$(shell go env GOOS)-$(shell go env GOARCH)
 STABLE_TAG ?= $(ARCH)-$(BASE_VERSION)-stable
@@ -53,9 +51,9 @@ FABRIC_TAG ?= $(ARCH)-$(BASE_VERSION)
 endif
 
 ifeq ($(ARCH),s390x)
-PG_VER=10
+PG_VER=11
 else
-PG_VER=10
+PG_VER=11
 endif
 
 PKGNAME = github.com/hyperledger/$(PROJECT_NAME)
@@ -150,7 +148,7 @@ build/image/fabric-ca-fvt/$(DUMMY):
 	$(eval TARGET = ${patsubst build/image/%/$(DUMMY),%,${@}})
 	@echo "Docker:  building $(TARGET) image"
 	$(DBUILD) -f images/$(TARGET)/Dockerfile \
-		--build-arg BASEIMAGE_RELEASE=${BASEIMAGE_RELEASE} \
+		--build-arg GO_VER=${GO_VER} \
 		--build-arg GO_TAGS=pkcs11 \
 		--build-arg GO_LDFLAGS="${DOCKER_GO_LDFLAGS}" \
 		--build-arg PG_VER=${PG_VER} \

--- a/images/fabric-ca-fvt/Dockerfile
+++ b/images/fabric-ca-fvt/Dockerfile
@@ -3,8 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-ARG BASEIMAGE_RELEASE
-FROM hyperledger/fabric-baseimage:${BASEIMAGE_RELEASE} as fabric-ca-builder
+ARG GO_VER
+FROM golang:${GO_VER}-buster as fabric-ca-builder
 ARG GO_LDFLAGS
 ARG GO_TAGS
 
@@ -16,8 +16,7 @@ RUN go build -tags "${GO_TAGS}" -ldflags "${GO_LDFLAGS}" \
 	-o /usr/local/bin/fabric-ca-client \
 	github.com/hyperledger/fabric-ca/cmd/fabric-ca-client;
 
-
-FROM hyperledger/fabric-baseimage:${BASEIMAGE_RELEASE}
+FROM debian:buster-20190910-slim
 ARG PG_VER
 
 ENV PATH="/usr/local/go/bin/:${PATH}" \
@@ -41,10 +40,10 @@ ENV PATH="/usr/local/go/bin/:${PATH}" \
     TLS_CLIENT_KEY=FabricTlsClientEEkey.pem \
     MYSQLDATA=/var/lib/mysql
 
+RUN apt-get clean && apt-get update && apt-get install openssl -y
+
 # setup scripts for slapd, postgres, mysql, and openssl
-COPY --from=fabric-ca-builder \
-	${GOPATH}/src/github.com/hyperledger/fabric-ca/images/fabric-ca-fvt/payload \
-	${FABRIC_CA_DATA}
+COPY ./images/fabric-ca-fvt/payload ${FABRIC_CA_DATA}
 RUN chmod +x ${FABRIC_CA_DATA}/*sh
 RUN cd ${FABRIC_CA_DATA}
 RUN $FABRIC_CA_DATA/tls_pki.sh
@@ -59,6 +58,8 @@ RUN ${FABRIC_CA_DATA}/system_update.sh
 RUN ${FABRIC_CA_DATA}/postgres_setup.sh
 RUN ${FABRIC_CA_DATA}/slapd_setup.sh
 RUN ${FABRIC_CA_DATA}/mysql_setup.sh
+
+COPY --from=fabric-ca-builder /usr/local/go /usr/local
 
 # Install fabric-ca dependencies
 RUN go get github.com/go-sql-driver/mysql

--- a/images/fabric-ca-fvt/payload/mysql_setup.sh
+++ b/images/fabric-ca-fvt/payload/mysql_setup.sh
@@ -2,6 +2,15 @@
 RC=0
 arch=$(uname -m)
 
+export DEBIAN_FRONTEND=noninteractive
+echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | debconf-set-selections
+wget https://dev.mysql.com/get/mysql-apt-config_0.8.13-1_all.deb
+dpkg -i mysql-apt-config_0.8.13-1_all.deb
+apt-get update
+apt-get install mysql-server -y
+service mysql start
+mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'mysql'"
+
 mkdir -p /var/run/mysqld
 chown mysql:mysql /var/run/mysqld
 

--- a/images/fabric-ca-fvt/payload/system_update.sh
+++ b/images/fabric-ca-fvt/payload/system_update.sh
@@ -17,12 +17,11 @@ printf "LANG=en_US.UTF-8\nLANGUAGE=en_US.UTF-8\n" > /etc/default/locale
 dpkg-reconfigure locales && update-locale LANG=en_US.UTF-8 || let RC+=1
 
 # Install more test depedencies
-echo "mysql-server mysql-server/root_password password mysql" | debconf-set-selections
-echo "mysql-server mysql-server/root_password_again password mysql" | debconf-set-selections
+
 apt-get -y install --no-install-recommends rsyslog bc vim lsof sqlite3 haproxy postgresql-$PGVER \
            postgresql-client-common postgresql-contrib-$PGVER isag jq git html2text \
            debconf-utils zsh htop python2.7-minimal libpython2.7-stdlib \
-           mysql-client  mysql-common mysql-server parallel || let RC+=1
+           parallel netcat wget lsb-release gnupg ca-certificates || let RC+=1
 apt-get -y install ssl-cert || let RC+=1
 apt-get -y autoremove
 


### PR DESCRIPTION
This PR replaces fabric baseimage, used as the base layer for the FVT image, with raw debian and golang base layers. The only utility we gain by using Fabric's historic baseimage is openssl and netcat being preinstalled in the image. Using a bloated base layer only raises the possibility of complications during upgrade cycles, as it's not readily apparent what is already in the image and what could be causing problems during test cycles.

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>