### PR TITLE
[FABC-884] Upgrade to go 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ else
 PGVER=10
 endif
 
-BASEIMAGE_RELEASE = 0.4.16
+BASEIMAGE_RELEASE = 0.4.18
 PKGNAME = github.com/hyperledger/$(PROJECT_NAME)
 
 METADATA_VAR = Version=$(PROJECT_VERSION)
@@ -125,7 +125,7 @@ build/docker/bin/%:
 		-v $(abspath build/docker/bin):/opt/gopath/bin \
 		-v $(abspath build/docker/$(@F)/pkg):/opt/gopath/pkg \
 		$(BASE_DOCKER_NS)/fabric-baseimage:$(BASE_DOCKER_TAG) \
-		go install -ldflags "$(DOCKER_GO_LDFLAGS)" $(PKGNAME)/$(path-map.${@F})
+		stat ${HOME}; go install -ldflags "$(DOCKER_GO_LDFLAGS)" $(PKGNAME)/$(path-map.${@F})
 	@touch $@
 
 build/image/%/$(DUMMY): Makefile build/image/%/payload

--- a/ci.properties
+++ b/ci.properties
@@ -1,11 +1,11 @@
 # Set base version from fabric branch
-FAB_BASE_VERSION=1.4.1
+FAB_BASE_VERSION=1.4.3
 # Set base image version from fabric branch
-FAB_BASEIMAGE_VERSION=0.4.15
+FAB_BASEIMAGE_VERSION=0.4.18
 # Pull below list of images from Hyperledger Docker Hub
 FAB_THIRDPARTY_IMAGES_LIST=kafka zookeeper couchdb
 # Set compaitable go version
-GO_VER=1.11.5
+GO_VER=1.12.12
 # Pull below list of images from nexus3 for e2e tests
 FAB_IMAGES_LIST=javaenv
 # Set related rocketChat channel name. Default: jenkins-robot

--- a/ci/azp-pipeline.yml
+++ b/ci/azp-pipeline.yml
@@ -15,7 +15,7 @@ pr:
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.11.5
+  GOVER: 1.12.12
 
 jobs:
 - job: VerifyBuild
@@ -43,6 +43,8 @@ jobs:
   - checkout: self
     path: 'go/src/github.com/hyperledger/fabric-ca'
     displayName: Checkout Fabric CA Code
+  - script: echo $HOME
+  - script: go env
   - script: make docker-fvt
     displayName: Build FVT Test Image
   - script: docker run -v $(pwd):/opt/gopath/src/github.com/hyperledger/fabric-ca hyperledger/fabric-ca-fvt

--- a/images/fabric-ca-fvt/Dockerfile.in
+++ b/images/fabric-ca-fvt/Dockerfile.in
@@ -24,7 +24,8 @@ ENV PATH="/usr/local/go/bin/:${PATH}" \
     TLS_SERVER_KEY=FabricTlsServerEEkey.pem \
     TLS_CLIENT_CERT=FabricTlsClientEEcert.pem \
     TLS_CLIENT_KEY=FabricTlsClientEEkey.pem \
-    MYSQLDATA=/var/lib/mysql
+    MYSQLDATA=/var/lib/mysql \
+    GOCACHE=/tmp/.gocache
 
 # setup scripts for slapd, postgres, mysql, and openssl
 ADD payload/fabric-ca-fvt.tar.bz2 $FABRIC_CA_DATA


### PR DESCRIPTION
This PR upgrades the baseimage to 0.4.18 which picks up the upgrade to go 1.12

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>