### PR TITLE
[FABC-884] Upgrade to go 1.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ else
 PGVER=10
 endif
 
-BASEIMAGE_RELEASE = 0.4.16
+BASEIMAGE_RELEASE = 0.4.18
 PKGNAME = github.com/hyperledger/$(PROJECT_NAME)
 
 METADATA_VAR = Version=$(PROJECT_VERSION)
@@ -120,10 +120,12 @@ bin/%: $(GO_SOURCE)
 # directory so that subsequent builds are faster
 build/docker/bin/%:
 	@echo "Building $@"
-	@mkdir -p $(@D) build/docker/$(@F)/pkg
+	@mkdir -p $(@D) build/docker/$(@F)/pkg build/docker/cache
 	@$(DRUN) \
 		-v $(abspath build/docker/bin):/opt/gopath/bin \
 		-v $(abspath build/docker/$(@F)/pkg):/opt/gopath/pkg \
+		-v $(abspath build/docker/cache):/opt/gopath/cache \
+		-e GOCACHE=/opt/gopath/cache \
 		$(BASE_DOCKER_NS)/fabric-baseimage:$(BASE_DOCKER_TAG) \
 		go install -ldflags "$(DOCKER_GO_LDFLAGS)" $(PKGNAME)/$(path-map.${@F})
 	@touch $@

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See [User's Guide for Fabric CA](https://hyperledger-fabric-ca.readthedocs.io) f
 
 ## Prerequisites
 
-* Go 1.11.5 installation or later
+* Go 1.12.12 installation or later
 * **GOPATH** environment variable is set correctly
 * docker version 17.06 or later
 * docker-compose version 1.14 or later

--- a/ci.properties
+++ b/ci.properties
@@ -1,11 +1,11 @@
 # Set base version from fabric branch
-FAB_BASE_VERSION=1.4.1
+FAB_BASE_VERSION=1.4.3
 # Set base image version from fabric branch
-FAB_BASEIMAGE_VERSION=0.4.15
+FAB_BASEIMAGE_VERSION=0.4.18
 # Pull below list of images from Hyperledger Docker Hub
 FAB_THIRDPARTY_IMAGES_LIST=kafka zookeeper couchdb
 # Set compaitable go version
-GO_VER=1.11.5
+GO_VER=1.12.12
 # Pull below list of images from nexus3 for e2e tests
 FAB_IMAGES_LIST=javaenv
 # Set related rocketChat channel name. Default: jenkins-robot

--- a/ci/azp-pipeline.yml
+++ b/ci/azp-pipeline.yml
@@ -4,18 +4,14 @@
 
 name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rrr)
 trigger:
-- master
-- release-2.*
 - release-1.4
 pr:
-- master
-- release-2.*
 - release-1.4
 
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.11.5
+  GOVER: 1.12.12
 
 jobs:
 - job: VerifyBuild

--- a/cmd/fabric-ca-client/command/gencrl.go
+++ b/cmd/fabric-ca-client/command/gencrl.go
@@ -143,6 +143,6 @@ func storeCRL(config *lib.ClientConfig, crl []byte) error {
 	if err != nil {
 		return errors.Wrapf(err, "Failed to write CRL to the file %s", fileName)
 	}
-	log.Info("Successfully stored the CRL in the file %s", fileName)
+	log.Infof("Successfully stored the CRL in the file %s", fileName)
 	return nil
 }

--- a/lib/client/credential/idemix/credential_test.go
+++ b/lib/client/credential/idemix/credential_test.go
@@ -77,14 +77,14 @@ func TestIdemixCredential(t *testing.T) {
 	assert.Error(t, err, "Store should return an error if credential has not been set")
 
 	err = idemixCred.Load()
-	assert.Error(t, err, "Load should fail as %s is not found", signerConfig)
+	assert.Errorf(t, err, "Load should fail as %s is not found", signerConfig)
 
 	err = ioutil.WriteFile(signerConfig, []byte("hello"), 0744)
 	if err != nil {
 		t.Fatalf("Failed to write to file %s: %s", signerConfig, err.Error())
 	}
 	err = idemixCred.Load()
-	assert.Error(t, err, "Load should fail as %s contains invalid data", signerConfig)
+	assert.Errorf(t, err, "Load should fail as %s contains invalid data", signerConfig)
 
 	err = lib.CopyFile(testSignerConfigFile, signerConfig)
 	if err != nil {
@@ -130,7 +130,7 @@ func TestIdemixCredential(t *testing.T) {
 		t.Fatalf("Failed to chmod SignerConfig file %s: %v", signerConfig, err)
 	}
 	err = idemixCred.Store()
-	assert.Error(t, err, "Store should fail as %s is not writable", signerConfig)
+	assert.Errorf(t, err, "Store should fail as %s is not writable", signerConfig)
 
 	if err = os.Chmod(signerConfig, 0644); err != nil {
 		t.Fatalf("Failed to chmod SignerConfig file %s: %v", signerConfig, err)
@@ -148,7 +148,7 @@ func TestIdemixCredential(t *testing.T) {
 		t.Fatalf("Failed to chmod SignerConfig file %s: %v", clientPubKeyFile, err)
 	}
 	_, err = idemixCred.CreateToken(req, body)
-	assert.Error(t, err, "CreateToken should fail as %s is not readable", clientPubKeyFile)
+	assert.Errorf(t, err, "CreateToken should fail as %s is not readable", clientPubKeyFile)
 
 	if err = os.Chmod(clientPubKeyFile, 0644); err != nil {
 		t.Fatalf("Failed to chmod SignerConfig file %s: %v", clientPubKeyFile, err)

--- a/lib/client/credential/x509/credential_test.go
+++ b/lib/client/credential/x509/credential_test.go
@@ -127,7 +127,7 @@ func TestX509Credential(t *testing.T) {
 		t.Fatalf("Failed to chmod certificate file %s: %s", certFile, err.Error())
 	}
 	err = x509Cred.Store()
-	assert.Error(t, err, "Store should fail as %s is not writable", certFile)
+	assert.Errorf(t, err, "Store should fail as %s is not writable", certFile)
 	if err = os.Chmod(certFile, 0644); err != nil {
 		t.Fatalf("Failed to chmod certificate file %s: %s", certFile, err.Error())
 	}

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -1311,12 +1311,6 @@ func TestNormalizeUrl(t *testing.T) {
 	} else {
 		t.Logf("URL %s, %s, %s", u.Scheme, u.Host, u.Path)
 	}
-	u, err = NormalizeURL("http://host:7054:x/path")
-	if err != nil {
-		t.Errorf("normalizeURL colons: %s", err)
-	} else {
-		t.Logf("URL %s, %s, %s", u.Scheme, u.Host, u.Path)
-	}
 	u, err = NormalizeURL("http://host:7054/path")
 	if err != nil {
 		t.Errorf("normalizeURL failed: %s", err)

--- a/lib/server/db/db_test.go
+++ b/lib/server/db/db_test.go
@@ -119,5 +119,5 @@ func TestCurrentDBLevels(t *testing.T) {
 	mockFabricCADB = &mocks.FabricCADB{}
 	levels, err := db.CurrentDBLevels(mockFabricCADB)
 	gt.Expect(err).NotTo(HaveOccurred())
-	gt.Expect(levels).To(Equal(&util.Levels{0, 0, 0, 0, 0, 0}))
+	gt.Expect(levels).To(Equal(&util.Levels{}))
 }

--- a/lib/server/ldap/client_test.go
+++ b/lib/server/ldap/client_test.go
@@ -96,7 +96,7 @@ func TestLDAPTLS(t *testing.T) {
 		t.Errorf("ldap.NewClient failure: %s", err)
 		return
 	}
-	testdata := "../../../../testdata"
+	testdata := "../../../testdata"
 	c.TLS.CertFiles = []string{filepath.Join(testdata, "root.pem")}
 	c.TLS.Client.CertFile = filepath.Join(testdata, "tls_client-cert.pem")
 	c.TLS.Client.KeyFile = filepath.Join(testdata, "tls_client-key.pem")

--- a/lib/server_test.go
+++ b/lib/server_test.go
@@ -715,7 +715,11 @@ func TestSRVRunningTLSServer(t *testing.T) {
 		})
 		t.Logf("Attempting TLS version [%d]", tlsVersion)
 		assert.Error(t, err, "Should not have been able to connect with TLS version < 1.2")
-		assert.Contains(t, err.Error(), "protocol version not supported")
+		if tlsVersion == tls.VersionSSL30 {
+			assert.Contains(t, err.Error(), "no supported versions satisfy MinVersion and MaxVersion")
+		} else {
+			assert.Contains(t, err.Error(), "protocol version not supported")
+		}
 	}
 }
 

--- a/scripts/check_vet
+++ b/scripts/check_vet
@@ -1,31 +1,15 @@
 #!/bin/bash
+
 #
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-function runvet {
- {
-   for dir in `ls`
-   do
-      if [ -d $dir ]; then
-        case "$dir" in
-          vendor|bin|testdata|scripts)
-          ;;
-        *)
-          go tool vet $dir
-          ;;
-        esac
-      fi
-   done
- } 2>&1
-}
 
-echo "Running go vet ..."
-found=$(runvet)
-if [ "$found" != "" ]; then
-   echo "YOU MUST FIX THE FOLLOWING GO VET PROBLEMS:"
-   echo "$found"
-   exit 1
+PRINTFUNCS="Print,Printf,Info,Infof,Warning,Warningf,Error,Errorf,Critical,Criticalf,Sprint,Sprintf,Log,Logf,Panic,Panicf,Fatal,Fatalf,Notice,Noticef,Wrap,Wrapf,WithMessage"
+OUTPUT="$(go vet -all -printfuncs $PRINTFUNCS ./...)"
+if [ -n "$OUTPUT" ]; then
+    echo "The following files contain go vet errors"
+    echo $OUTPUT
+    exit 1
 fi
-echo "No 'go vet' problems were found"


### PR DESCRIPTION
Use the new release of baseimage and pass the GOCACHE into the build process.

Cherry-Picked FABC-873 and FABC-844

Also fixed the failing test due to divergent error message output depending depending on the TLS version introduced in Go 1.12

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>