### PR TITLE
[FABCI-461] Create release job

### DIFF
--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -1,0 +1,89 @@
+# Copyright the Hyperledger Fabric cont ributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: RELEASE-$(Date:yyyyMMdd)$(Rev:.rrr)
+trigger: none
+pr: none
+
+variables:
+  - group: credentials
+  - name: GOPATH
+    value: $(Agent.BuildDirectory)/go
+  - name: GOVER
+    value: 1.12.12
+
+stages:
+  - stage: BuildBinaries
+    dependsOn: []
+    displayName: "Build Fabric CA Binaries"
+    jobs:
+      - job: Build
+        pool:
+          vmImage: ubuntu-16.04
+        container: golang:$(GOVER)
+        strategy:
+          matrix:
+            Linux-amd64:
+              TARGET: linux-amd64
+            MacOS-amd64:
+              TARGET: darwin-amd64
+            Windows-amd64:
+              TARGET: windows-amd64
+        steps:
+          - checkout: self
+            path: 'go/src/github.com/hyperledger/fabric-ca'
+            displayName: Checkout Fabric CA Code
+          - script: ./ci/create_binary_package.sh
+            displayName: Compile Binary and Create Tarball
+          - publish: release/$(TARGET)/bin/$(TARGET)-$(RELEASE).tar.gz
+            artifact: $(TARGET).tar.gz
+            displayName: Publish Release Artifact
+
+  - stage: BuildAndPushDockerImages
+    dependsOn: []
+    displayName: "Build and Push Fabric CA Docker Images"
+    jobs:
+      - job: Docker
+        pool:
+          vmImage: ubuntu-16.04
+        steps:
+          - template: install_deps.yml
+          - checkout: self
+            path: 'go/src/github.com/hyperledger/fabric-ca'
+            displayName: Checkout Fabric CA Code
+          - script: ./ci/publish_docker.sh
+            env:
+              DOCKER_PASSWORD: $(DockerHub-Password)
+              DOCKER_USERNAME: $(DockerHub-Username)
+            displayName: Publish Docker Images
+
+  - stage: DraftRelease
+    displayName: "Draft GitHub Release"
+    dependsOn:
+      - BuildBinaries
+      - BuildAndPushDockerImages
+    jobs:
+      - job: Release
+        pool:
+          vmImage: ubuntu-16.04
+        steps:
+          - download: current
+            patterns: '*.tar.gz'
+            displayName: Download Artifacts
+          - checkout: self
+          - task: GitHubRelease@0
+            inputs:
+              action: create
+              addChangeLog: true
+              assets: $(Pipeline.Workspace)/*amd64*/*
+              compareWith: lastFullRelease
+              gitHubConnection: fabric-ca-release
+              isDraft: true
+              releaseNotesFile: release_notes/v$(RELEASE).md
+              repositoryName: $(Build.Repository.Name)
+              releaseNotesSource: file
+              tag: v$(RELEASE)
+              tagSource: manual
+              title: v$(RELEASE)
+            displayName: Draft Release of Fabric CA

--- a/ci/create_binary_package.sh
+++ b/ci/create_binary_package.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+set -eu -o pipefail
+
+make "release/${TARGET}"
+cd "release/${TARGET}/bin"
+tar -czvf "${TARGET}-${RELEASE}.tar.gz" "fabric-ca-client"

--- a/ci/publish_docker.sh
+++ b/ci/publish_docker.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+set -eu -o pipefail
+
+make docker
+docker login --username "${DOCKER_USERNAME}" --password "${DOCKER_PASSWORD}"
+docker tag "hyperledger/fabric-ca" "hyperledger/fabric-ca:amd64-${RELEASE}"
+docker push "hyperledger/fabric-ca:amd64-${RELEASE}"
+
+wget -qO "$PWD/manifest-tool" https://github.com/estesp/manifest-tool/releases/download/v1.0.0/manifest-tool-linux-amd64
+chmod +x ./manifest-tool
+./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-ca:amd64-${RELEASE}" --target "hyperledger/fabric-ca:${RELEASE}"
+./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-ca:amd64-${RELEASE}" --target "hyperledger/fabric-ca:$(sed 's/..$//' <<< ${RELEASE})"
+./manifest-tool push from-args --platforms linux/amd64 --template "hyperledger/fabric-ca:amd64-${RELEASE}" --target "hyperledger/fabric-ca:latest"


### PR DESCRIPTION
This change adds an Azure Pipelines yaml
definition for a release pipeline. It builds the
fabric-CA binaries, builds and publishes the
fabric-ca docker images to dockerhub, and
creates a draft GitHub release that includes
the existing changlelog and binaries.

Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>