### PR TITLE
[FABC-888] Update Go to 1.13.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ METADATA_VAR = Version=$(PROJECT_VERSION)
 
 # hardcode until release jobs migrate to new CI
 # GO_VER = $(shell grep "GO_VER" ci.properties | cut -d '=' -f2-)
-GO_VER = 1.12.9
+GO_VER = 1.13.4
 GO_SOURCE := $(shell find . -name '*.go')
 GO_LDFLAGS = $(patsubst %,-X $(PKGNAME)/lib/metadata.%,$(METADATA_VAR))
 export GO_LDFLAGS

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See [User's Guide for Fabric CA](https://hyperledger-fabric-ca.readthedocs.io) f
 
 ## Prerequisites
 
-* Go 1.10+ installation or later
+* Go 1.13+ installation or later
 * **GOPATH** environment variable is set correctly
 * docker version 17.03 or later
 * docker-compose version 1.11 or later

--- a/ci.properties
+++ b/ci.properties
@@ -1,11 +1,11 @@
 # Set base version from fabric branch
 FAB_BASE_VERSION=2.0.0
 # Set base image version from fabric branch
-FAB_BASEIMAGE_VERSION=0.4.15
+FAB_BASEIMAGE_VERSION=0.4.18
 # Pull below list of images from Hyperledger Docker Hub
 FAB_THIRDPARTY_IMAGES_LIST=kafka zookeeper couchdb
 # Set compatible go version
-GO_VER=1.12.5
+GO_VER=1.13.4
 # Pull below list of images from nexus3 for e2e tests
 FAB_IMAGES_LIST=javaenv nodeenv
 # Set related rocketChat channel name. Default: jenkins-robot

--- a/ci/azp-pipeline.yml
+++ b/ci/azp-pipeline.yml
@@ -15,7 +15,7 @@ pr:
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-ca/build/tools:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.12.9
+  GOVER: 1.13.4
 
 jobs:
 - job: VerifyBuild


### PR DESCRIPTION
Signed-off-by: Brett Logan <Brett.T.Logan@ibm.com>

This change updates the Go version to 1.13.4 in CI and the build images

#### Type of change

- Improvement

#### Description

This brings Fabric-CA in line with Fabric Core for the supported Go Versions
