### PR TITLE
FABC-806 Do not honor client expiry request

### DIFF
--- a/lib/serverenroll.go
+++ b/lib/serverenroll.go
@@ -106,16 +106,15 @@ func handleEnroll(ctx *serverRequestContextImpl, id string) (interface{}, error)
 	if err != nil {
 		return nil, err
 	}
-	// If NotAfter is not set in the request, then set it to the expiry in the
-	// specified profile
-	if req.NotAfter.IsZero() {
-		profile := ca.Config.Signing.Default
-		if req.Profile != "" && ca.Config.Signing != nil &&
-			ca.Config.Signing.Profiles != nil && ca.Config.Signing.Profiles[req.Profile] != nil {
-			profile = ca.Config.Signing.Profiles[req.Profile]
-		}
-		req.NotAfter = time.Now().Round(time.Minute).Add(profile.Expiry).UTC()
+	// Set expiry based on the requested CA profile else use expiry from the default
+	// profile
+	profile := ca.Config.Signing.Default
+	if req.Profile != "" && ca.Config.Signing != nil &&
+		ca.Config.Signing.Profiles != nil && ca.Config.Signing.Profiles[req.Profile] != nil {
+		profile = ca.Config.Signing.Profiles[req.Profile]
 	}
+	req.NotAfter = time.Now().Round(time.Minute).Add(profile.Expiry).UTC()
+
 	caexpiry, err := ca.getCACertExpiry()
 	if err != nil {
 		return nil, errors.New("Failed to get CA certificate information")


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

The expiry for issued certificates should always be set by the CA and not by the client.
While none of the existing SDKs or clients actually set the expiry, it's possible to do so if you call the API directly (due to an embedded cfssl type).


#### Additional details

Not sure why the code was there in the first place as there's no documented or intended path to actually use it.

#### Related issues

[FABC-806](https://jira.hyperledger.org/browse/FABC-806)

#### Release Note

This should not impact existing users as it is not even documented in the Swagger API and as mentioned earlier none of the SDKs or clients set the expiry.


