### PR TITLE
[FABC-892] Includes pkcs11 under bccsp section of default config files

### DIFF
--- a/cmd/fabric-ca-client/command/config.go
+++ b/cmd/fabric-ca-client/command/config.go
@@ -186,7 +186,8 @@ caname:
 
 #############################################################################
 # BCCSP (BlockChain Crypto Service Provider) section allows to select which
-# crypto implementation library to use
+# crypto implementation library to use. Change "default:" value to match the
+# provider (SW or PKCS11).
 #############################################################################
 bccsp:
     default: SW
@@ -196,6 +197,16 @@ bccsp:
         filekeystore:
             # The directory used for the software file-based keystore
             keystore: msp/keystore
+
+    # PKCS11 provider definitions, for use with an HSM
+    pkcs11:
+        Library:
+        Pin:
+        Label:
+        hash: SHA2
+        security: 256
+        filekeystore:
+            keystore:	
 `
 )
 

--- a/cmd/fabric-ca-server/config.go
+++ b/cmd/fabric-ca-server/config.go
@@ -379,7 +379,8 @@ idemix:
 
 #############################################################################
 # BCCSP (BlockChain Crypto Service Provider) section is used to select which
-# crypto library implementation to use
+# crypto library implementation to use. Change "default:" value to match the
+# provider (SW or PKCS11).
 #############################################################################
 bccsp:
     default: SW
@@ -389,6 +390,16 @@ bccsp:
         filekeystore:
             # The directory used for the software file-based keystore
             keystore: msp/keystore
+
+    # PKCS11 provider definitions, for use with an HSM
+    pkcs11:
+        Library:
+        Pin:
+        Label:
+        hash: SHA2
+        security: 256
+        filekeystore:
+            keystore:
 
 #############################################################################
 # Multi CA section


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

This fixes an issue with environment variables that are ignored by the fabric-ca-server and fabric-ca-client when they don't exist in the config file. Previous behavior prevented the use of environment variables to initialize Fabric CA integrated with an HSM.

#### Related issues

[FABC-892](https://jira.hyperledger.org/browse/FABC-892)




