### PR TITLE
Support reading Operations TLS settings from file

### DIFF
--- a/cmd/fabric-ca-server/config.go
+++ b/cmd/fabric-ca-server/config.go
@@ -576,23 +576,28 @@ func (s *ServerCmd) configInit() (err error) {
 	// Read operations tls files
 	if s.myViper.GetBool("operations.tls.enabled") {
 		cf := s.myViper.GetString("operations.tls.cert.file")
+		if cf == "" {
+			cf = s.cfg.Operations.TLS.CertFile
+		}
 		if !filepath.IsAbs(cf) {
 			cf = filepath.Join(s.homeDirectory, cf)
 		}
-		if util.FileExists(cf) {
-			s.cfg.Operations.TLS.CertFile = cf
-		} else {
+		if !util.FileExists(cf) {
 			return errors.Errorf("failed to read certificate file: %s", cf)
 		}
+		s.cfg.Operations.TLS.CertFile = cf
+
 		kf := s.myViper.GetString("operations.tls.key.file")
+		if kf == "" {
+			kf = s.cfg.Operations.TLS.KeyFile
+		}
 		if !filepath.IsAbs(kf) {
 			kf = filepath.Join(s.homeDirectory, kf)
 		}
-		if util.FileExists(kf) {
-			s.cfg.Operations.TLS.KeyFile = kf
-		} else {
+		if !util.FileExists(kf) {
 			return errors.Errorf("failed to read key file: %s", kf)
 		}
+		s.cfg.Operations.TLS.KeyFile = kf
 	}
 
 	// The pathlength field controls how deep the CA hierarchy when requesting

--- a/cmd/fabric-ca-server/main_test.go
+++ b/cmd/fabric-ca-server/main_test.go
@@ -540,3 +540,29 @@ func TestConfigInit(t *testing.T) {
 		os.Remove(defYaml)
 	}
 }
+
+func TestOperationsTLSCertKeyConfig(t *testing.T) {
+	certFile := "tls_server-cert.pem"
+	keyFile := "tls_server-key.pem"
+
+	cmd := &ServerCmd{
+		myViper:     viper.New(),
+		cfgFileName: "../../testdata/testviperunmarshal.yaml",
+		cfg:         &lib.ServerConfig{},
+	}
+	cmd.myViper.Set("boot", "user:pass")
+
+	err := cmd.configInit()
+	if err != nil {
+		t.Error(err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %s", err)
+	}
+	homeDir := filepath.Join(cwd, "../../testdata")
+
+	assert.Equal(t, cmd.cfg.Operations.TLS.CertFile, filepath.Join(homeDir, certFile))
+	assert.Equal(t, cmd.cfg.Operations.TLS.KeyFile, filepath.Join(homeDir, keyFile))
+}

--- a/lib/caconfig.go
+++ b/lib/caconfig.go
@@ -88,7 +88,7 @@ type CAConfig struct {
 	Affiliations map[string]interface{}
 	LDAP         ldap.Config
 	DB           CAConfigDB
-	CSP          *factory.FactoryOpts `mapstructure:"bccsp" hide:"true"`
+	CSP          *factory.FactoryOpts `yaml:"bccsp" mapstructure:"bccsp" hide:"true"`
 	// Optional client config for an intermediate server which acts as a client
 	// of the root (or parent) server
 	Client       *ClientConfig `skip:"true"`

--- a/testdata/testviperunmarshal.yaml
+++ b/testdata/testviperunmarshal.yaml
@@ -9,3 +9,9 @@ ca:
 db:
   tls:
       enabled: false
+
+operations:
+  tls:
+    enabled: true
+    certfile: "tls_server-cert.pem"
+    keyfile: "tls_server-key.pem"


### PR DESCRIPTION
Change-Id: Idbec67be0e71c0f11f724b5222f5ff974bff4db6
Signed-off-by: Saad Karim <skarim@us.ibm.com>

#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Currently, the unmarshal of server's configuration file
does not pull operations config in correctly. Operations
config is overridden always by reading in value from
"operations.tls.cert.file" and "operations.tls.cert.key".
If these are not set then values from file are overridden
with blank values. This code was revised to check for both
ways of setting operation's TLS config.

Also, added `yaml` tag on CSP field to support serialization
using yaml.
