### PR TITLE
Fix table in user guide (currently not rendered in html due to this)

### DIFF
--- a/docs/source/users-guide.rst
+++ b/docs/source/users-guide.rst
@@ -1414,7 +1414,7 @@ The names of attributes are case sensitive.
 +-----------------------------+------------+------------------------------------------------------------------------------------------------------------+
 | hf.GenCRL                   | Boolean    | Identity is able to generate CRL if attribute value is true                                                |
 +-----------------------------+------------+------------------------------------------------------------------------------------------------------------+
-| hf.Revoker                  | Boolean    | Identity is able to revoke an identity and/or certificates if attribute value is true                           |
+| hf.Revoker                  | Boolean    | Identity is able to revoke an identity and/or certificates if attribute value is true                      |
 +-----------------------------+------------+------------------------------------------------------------------------------------------------------------+
 | hf.AffiliationMgr           | Boolean    | Identity is able to manage affiliations if attribute value is true                                         |
 +-----------------------------+------------+------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
Signed-off-by: barney2k7 <barney2k7@users.noreply.github.com>

#### Type of change

- Documentation update

#### Description

The table attributes that can be registered for an identity in the user guide is currently not rendered in html due to invalid syntax.
This PR fixes the broken table
