### PR TITLE
Fix dead link to Fabric's CONTRIBUTING docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributions Welcome!
 
 This repository is part of the Fabric project.
-Please consult [Fabric's CONTRIBUTING documentation](https://github.com/hyperledger/fabric/blob/master/docs/CONTRIBUTING.md) for information on how to contribute to this repository.
+Please consult [Fabric's CONTRIBUTING documentation](https://github.com/hyperledger/fabric/blob/master/CONTRIBUTING.md) for information on how to contribute to this repository.
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
Signed-off-by: barney2k7 <barney2k7@users.noreply.github.com>

#### Type of change

- Documentation update

#### Description

The link to Fabric's CONTRIBUTING documentation was dead. Plus the line endings were inconsistent.
