### PR TITLE
Remove call to InitFactories

### DIFF
--- a/lib/capkcs11_test.go
+++ b/lib/capkcs11_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"testing"
 
+	dbutil "github.com/hyperledger/fabric-ca/lib/server/db/util"
 	"github.com/hyperledger/fabric/bccsp/factory"
 	"github.com/hyperledger/fabric/bccsp/pkcs11"
 )
@@ -39,7 +40,14 @@ func TestCAInit(t *testing.T) {
 	t.Log("Working dir", wd)
 	defer cleanupTmpfiles(t, wd)
 	cfgFile := serverCfgFile(".")
-	ca, err := newCA(cfgFile, &cfg, &srv, false)
+	server := &Server{
+		levels: &dbutil.Levels{
+			Identity:    1,
+			Affiliation: 1,
+			Certificate: 1,
+		},
+	}
+	ca, err := newCA(cfgFile, &CAConfig{}, server, false)
 	if err != nil {
 		t.Fatal("newCA FAILED")
 	}
@@ -71,7 +79,7 @@ func TestCAInit(t *testing.T) {
 	defer cleanupTmpfiles(t, wd2)
 
 	ca.Config.CSP = &factory.FactoryOpts{ProviderName: "SW", SwOpts: swo, Pkcs11Opts: pko}
-	ca, err = newCA(cfgFile, &cfg, &srv, true)
+	ca, err = newCA(cfgFile, &CAConfig{}, server, true)
 	if err != nil {
 		t.Fatal("newCA FAILED", err)
 	}
@@ -102,7 +110,7 @@ func TestCAInit(t *testing.T) {
 	ca.Config.CA.Keyfile = ""
 	ca.Config.CA.Certfile = ""
 	ca.Config.DB.Datasource = ""
-	ca, err = newCA(cfgFile, &cfg, &srv, false)
+	ca, err = newCA(cfgFile, &CAConfig{}, server, false)
 	if err != nil {
 		t.Fatal("newCA FAILED: ", err)
 	}
@@ -122,7 +130,7 @@ func TestCAInit(t *testing.T) {
 
 	// initEnrollmentSigner error
 	ca.Config.LDAP.Enabled = false
-	ca, err = newCA(cfgFile, &cfg, &srv, false)
+	ca, err = newCA(cfgFile, &CAConfig{}, server, false)
 	if err != nil {
 		t.Fatal("newCA FAILED")
 	}

--- a/util/configurebccsp.go
+++ b/util/configurebccsp.go
@@ -61,11 +61,6 @@ func ConfigureBCCSP(optsPtr **factory.FactoryOpts, mspDir, homeDir string) error
 	if opts.Pkcs11Opts != nil {
 		log.Debugf("Initializing BCCSP with PKCS11 options %+v", opts.Pkcs11Opts)
 	}
-	// Init the BCCSP factories
-	err = factory.InitFactories(opts)
-	if err != nil {
-		return errors.WithMessage(err, "Failed to initialize BCCSP Factories")
-	}
 	*optsPtr = opts
 	return nil
 }

--- a/util/configurebccspnopkcs11.go
+++ b/util/configurebccspnopkcs11.go
@@ -58,11 +58,6 @@ func ConfigureBCCSP(optsPtr **factory.FactoryOpts, mspDir, homeDir string) error
 	if opts.SwOpts != nil {
 		log.Debugf("Initializing BCCSP with software options %+v", opts.SwOpts)
 	}
-	// Init the BCCSP factories
-	err = factory.InitFactories(opts)
-	if err != nil {
-		return errors.WithMessage(err, "Failed to initialize BCCSP Factories")
-	}
 	*optsPtr = opts
 	return nil
 }


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

This change allows the fabric-ca to be used as a library with the ability to reload the bccsp config in the case where there is an error.

In util/csp.go, GetBCCSP actually calls factory.GetBCCSPFromOpts to configure the crypto provider. This removes the need to call factory.InitFactories (which is only ever called once and prevents reload of the bccsp config)