### PR TITLE
[FAB-17517] Only Initialize specified BCCSP provider

### DIFF
--- a/vendor/github.com/hyperledger/fabric/bccsp/factory/nopkcs11.go
+++ b/vendor/github.com/hyperledger/fabric/bccsp/factory/nopkcs11.go
@@ -52,7 +52,7 @@ func InitFactories(config *FactoryOpts) error {
 		bccspMap = make(map[string]bccsp.BCCSP)
 
 		// Software-Based BCCSP
-		if config.SwOpts != nil {
+		if config.ProviderName == "SW" && config.SwOpts != nil {
 			f := &SWFactory{}
 			err := initBCCSP(f, config)
 			if err != nil {
@@ -61,11 +61,11 @@ func InitFactories(config *FactoryOpts) error {
 		}
 
 		// BCCSP Plugin
-		if config.PluginOpts != nil {
+		if config.ProviderName == "PLUGIN" && config.PluginOpts != nil {
 			f := &PluginFactory{}
 			err := initBCCSP(f, config)
 			if err != nil {
-				factoriesInitError = errors.Wrapf(err, "Failed initializing PKCS11.BCCSP %s", factoriesInitError)
+				factoriesInitError = errors.Wrapf(err, "Failed initializing PLUGIN.BCCSP %s", factoriesInitError)
 			}
 		}
 

--- a/vendor/github.com/hyperledger/fabric/bccsp/factory/pkcs11.go
+++ b/vendor/github.com/hyperledger/fabric/bccsp/factory/pkcs11.go
@@ -61,7 +61,7 @@ func setFactories(config *FactoryOpts) error {
 	bccspMap = make(map[string]bccsp.BCCSP)
 
 	// Software-Based BCCSP
-	if config.SwOpts != nil {
+	if config.ProviderName == "SW" && config.SwOpts != nil {
 		f := &SWFactory{}
 		err := initBCCSP(f, config)
 		if err != nil {
@@ -70,7 +70,7 @@ func setFactories(config *FactoryOpts) error {
 	}
 
 	// PKCS11-Based BCCSP
-	if config.Pkcs11Opts != nil {
+	if config.ProviderName == "PKCS11" && config.Pkcs11Opts != nil {
 		f := &PKCS11Factory{}
 		err := initBCCSP(f, config)
 		if err != nil {
@@ -79,11 +79,11 @@ func setFactories(config *FactoryOpts) error {
 	}
 
 	// BCCSP Plugin
-	if config.PluginOpts != nil {
+	if config.ProviderName == "PLUGIN" && config.PluginOpts != nil {
 		f := &PluginFactory{}
 		err := initBCCSP(f, config)
 		if err != nil {
-			factoriesInitError = errors.Wrapf(err, "Failed initializing PKCS11.BCCSP %s", factoriesInitError)
+			factoriesInitError = errors.Wrapf(err, "Failed initializing PLUGIN.BCCSP %s", factoriesInitError)
 		}
 	}
 


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
Code currently tries to initialize multiple providers based on
provided config Opts being nil or not.

This update ensures that only specified provider is initialized
based on ProviderName.

This fixes "Failed initializing PKCS11.BCCSP %!s(<nil>)" error
when the code complied with PKCS11 enabled expect
configuration to not be nil even when Provider is set to SW.

Signed-off-by: Ahmed Sajid <ahmed.sajid@securekey.com>

#### Related issues
https://jira.hyperledger.org/browse/FAB-17517
https://github.com/hyperledger/fabric-ca/pull/113
https://github.com/hyperledger/fabric/pull/769
https://github.com/hyperledger/fabric/pull/821
https://github.com/hyperledger/fabric/pull/822