### PR TITLE
Revert label help and replace with info in metrics template

### DIFF
--- a/docs/source/metrics_reference.rst
+++ b/docs/source/metrics_reference.rst
@@ -1,59 +1,64 @@
 Metrics Reference
 =================
 
+Metrics exposed by the Fabric CA include *labels* to differentiate various
+characteristics of the item being measured. Five different labels are used.
+
+  api_name
+    For API requests, this is the path of the requested resource with the version
+    prefix removed. The list of resource paths can be found in the
+    `Swagger API Documentation <https://github.com/hyperledger/fabric-ca/blob/master/swagger/swagger-fabric-ca.json>`_.
+    Examples include ``cainfo``, register``, and ``enroll``.
+
+  ca_name
+    The name of the certificate authority associated with the metric.
+
+  db_api_name
+    For database requests, this contains the SQL operation that was used.
+    Examples include ``Commit``, ``Exec``, ``Get``, ``NamedExec``, ``Select``,
+    and ``Queryx``
+
+  func_name
+    For database access, this includes the name of the function that initiated
+    the database request. Examples include ``GetUser``, ``InsertUser``,
+    ``LoginComplete``, and  ``ResetIncorrectLoginAttempts``.
+
+  status_code
+    For API requests, this is the HTTP status code of the response. Successful
+    requests will have status codes that are less than 400.
+
 Prometheus Metrics
 ------------------
 
 The following metrics are currently exported for consumption by Prometheus.
 
-+-------------------------+-----------+------------------------------------------------------------+--------------------------------------------------------------------------------+
-| Name                    | Type      | Description                                                | Labels                                                                         |
-+=========================+===========+============================================================+=============+==================================================================+
-| api_request_count       | counter   | Number of requests made to an API                          | ca_name     |                                                                  |
-|                         |           |                                                            +-------------+------------------------------------------------------------------+
-|                         |           |                                                            | api_name    | example api_names: affiliations/{affiliation}, affiliations,     |
-|                         |           |                                                            |             | certificates, enroll, reenroll, gencrl, idemix/cri, identities,  |
-|                         |           |                                                            |             | register, revoke, idemix/credential, identities/{id}.            |
-|                         |           |                                                            +-------------+------------------------------------------------------------------+
-|                         |           |                                                            | status_code | Http status code.                                                |
-|                         |           |                                                            |             | https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html          |
-+-------------------------+-----------+------------------------------------------------------------+-------------+------------------------------------------------------------------+
-| api_request_duration    | histogram | Time taken in seconds for the request to an API to be      | ca_name     |                                                                  |
-|                         |           | completed                                                  +-------------+------------------------------------------------------------------+
-|                         |           |                                                            | api_name    | example api_names: affiliations/{affiliation}, affiliations,     |
-|                         |           |                                                            |             | certificates, enroll, reenroll, gencrl, idemix/cri, identities,  |
-|                         |           |                                                            |             | register, revoke, idemix/credential, identities/{id}.            |
-|                         |           |                                                            +-------------+------------------------------------------------------------------+
-|                         |           |                                                            | status_code | Http status code.                                                |
-|                         |           |                                                            |             | https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html          |
-+-------------------------+-----------+------------------------------------------------------------+-------------+------------------------------------------------------------------+
-| db_api_request_count    | counter   | Number of requests made to a database API                  | ca_name     |                                                                  |
-|                         |           |                                                            +-------------+------------------------------------------------------------------+
-|                         |           |                                                            | func_name   |                                                                  |
-|                         |           |                                                            +-------------+------------------------------------------------------------------+
-|                         |           |                                                            | dbapi_name  | example dbapi_names: affiliations/{affiliation}, affiliations,   |
-|                         |           |                                                            |             | certificates, enroll, reenroll, gencrl, idemix/cri, identities,  |
-|                         |           |                                                            |             | register, revoke, idemix/credential, identities/{id}.            |
-+-------------------------+-----------+------------------------------------------------------------+-------------+------------------------------------------------------------------+
-| db_api_request_duration | histogram | Time taken in seconds for the request to a database API to | ca_name     |                                                                  |
-|                         |           | be completed                                               +-------------+------------------------------------------------------------------+
-|                         |           |                                                            | func_name   |                                                                  |
-|                         |           |                                                            +-------------+------------------------------------------------------------------+
-|                         |           |                                                            | dbapi_name  | example dbapi_names: affiliations/{affiliation}, affiliations,   |
-|                         |           |                                                            |             | certificates, enroll, reenroll, gencrl, idemix/cri, identities,  |
-|                         |           |                                                            |             | register, revoke, idemix/credential, identities/{id}.            |
-+-------------------------+-----------+------------------------------------------------------------+-------------+------------------------------------------------------------------+
++-------------------------+-----------+------------------------------------------------------------+--------------------+
+| Name                    | Type      | Description                                                | Labels             |
++=========================+===========+============================================================+====================+
+| api_request_count       | counter   | Number of requests made to an API                          | ca_name            |
+|                         |           |                                                            | api_name           |
+|                         |           |                                                            | status_code        |
++-------------------------+-----------+------------------------------------------------------------+--------------------+
+| api_request_duration    | histogram | Time taken in seconds for the request to an API to be      | ca_name            |
+|                         |           | completed                                                  | api_name           |
+|                         |           |                                                            | status_code        |
++-------------------------+-----------+------------------------------------------------------------+--------------------+
+| db_api_request_count    | counter   | Number of requests made to a database API                  | ca_name            |
+|                         |           |                                                            | func_name          |
+|                         |           |                                                            | dbapi_name         |
++-------------------------+-----------+------------------------------------------------------------+--------------------+
+| db_api_request_duration | histogram | Time taken in seconds for the request to a database API to | ca_name            |
+|                         |           | be completed                                               | func_name          |
+|                         |           |                                                            | dbapi_name         |
++-------------------------+-----------+------------------------------------------------------------+--------------------+
 
 
 StatsD Metrics
 --------------
 
 The following metrics are currently emitted for consumption by StatsD. The
-``%{variable_name}`` nomenclature represents segments that vary based on
-context.
-
-For example, ``%{channel}`` will be replaced with the name of the channel
-associated with the metric.
+``%{label_name}`` nomenclature indicates the location of a label value in the
+bucket name.
 
 +---------------------------------------------------------------+-----------+------------------------------------------------------------+
 | Bucket                                                        | Type      | Description                                                |

--- a/docs/source/metrics_reference.rst.tmpl
+++ b/docs/source/metrics_reference.rst.tmpl
@@ -4,6 +4,32 @@
 Metrics Reference
 =================
 
+Metrics exposed by the Fabric CA include *labels* to differentiate various
+characteristics of the item being measured. Five different labels are used.
+
+  api_name
+    For API requests, this is the path of the requested resource with the version
+    prefix removed. The list of resource paths can be found in the
+    `Swagger API Documentation <https://github.com/hyperledger/fabric-ca/blob/master/swagger/swagger-fabric-ca.json>`_.
+    Examples include ``cainfo``, register``, and ``enroll``.
+
+  ca_name
+    The name of the certificate authority associated with the metric.
+
+  db_api_name
+    For database requests, this contains the SQL operation that was used.
+    Examples include ``Commit``, ``Exec``, ``Get``, ``NamedExec``, ``Select``,
+    and ``Queryx``
+
+  func_name
+    For database access, this includes the name of the function that initiated
+    the database request. Examples include ``GetUser``, ``InsertUser``,
+    ``LoginComplete``, and  ``ResetIncorrectLoginAttempts``.
+
+  status_code
+    For API requests, this is the HTTP status code of the response. Successful
+    requests will have status codes that are less than 400.
+
 Prometheus Metrics
 ------------------
 
@@ -15,11 +41,8 @@ StatsD Metrics
 --------------
 
 The following metrics are currently emitted for consumption by StatsD. The
-``%{variable_name}`` nomenclature represents segments that vary based on
-context.
-
-For example, ``%{channel}`` will be replaced with the name of the channel
-associated with the metric.
+``%{label_name}`` nomenclature indicates the location of a label value in the
+bucket name.
 
 {{ StatsdTable }}
 

--- a/lib/server/db/metrics.go
+++ b/lib/server/db/metrics.go
@@ -11,29 +11,21 @@ import "github.com/hyperledger/fabric/common/metrics"
 var (
 	// APICounterOpts define the counter opts for database APIs
 	APICounterOpts = metrics.CounterOpts{
-		Namespace:  "db_api_request",
-		Subsystem:  "",
-		Name:       "count",
-		Help:       "Number of requests made to a database API",
-		LabelNames: []string{"ca_name", "func_name", "dbapi_name"},
-		LabelHelp: map[string]string{
-			"dbapi_name":  "example dbapi_names: affiliations/{affiliation}, affiliations, certificates, enroll, reenroll, gencrl, idemix/cri, identities, register, revoke, idemix/credential, identities/{id}. ",
-			"status_code": "Http status code. https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-		},
+		Namespace:    "db_api_request",
+		Subsystem:    "",
+		Name:         "count",
+		Help:         "Number of requests made to a database API",
+		LabelNames:   []string{"ca_name", "func_name", "dbapi_name"},
 		StatsdFormat: "%{#fqname}.%{ca_name}.%{func_name}.%{dbapi_name}",
 	}
 
 	// APIDurationOpts define the duration opts for database APIs
 	APIDurationOpts = metrics.HistogramOpts{
-		Namespace:  "db_api_request",
-		Subsystem:  "",
-		Name:       "duration",
-		Help:       "Time taken in seconds for the request to a database API to be completed",
-		LabelNames: []string{"ca_name", "func_name", "dbapi_name"},
-		LabelHelp: map[string]string{
-			"dbapi_name":  "example dbapi_names: affiliations/{affiliation}, affiliations, certificates, enroll, reenroll, gencrl, idemix/cri, identities, register, revoke, idemix/credential, identities/{id}. ",
-			"status_code": "Http status code. https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-		},
+		Namespace:    "db_api_request",
+		Subsystem:    "",
+		Name:         "duration",
+		Help:         "Time taken in seconds for the request to a database API to be completed",
+		LabelNames:   []string{"ca_name", "func_name", "dbapi_name"},
 		StatsdFormat: "%{#fqname}.%{ca_name}.%{func_name}.%{dbapi_name}",
 	}
 )

--- a/lib/server/metrics/metrics.go
+++ b/lib/server/metrics/metrics.go
@@ -11,29 +11,21 @@ import "github.com/hyperledger/fabric/common/metrics"
 var (
 	// APICounterOpts define the counter opts for server APIs
 	APICounterOpts = metrics.CounterOpts{
-		Namespace:  "api_request",
-		Subsystem:  "",
-		Name:       "count",
-		Help:       "Number of requests made to an API",
-		LabelNames: []string{"ca_name", "api_name", "status_code"},
-		LabelHelp: map[string]string{
-			"api_name":    "example api_names: affiliations/{affiliation}, affiliations, certificates, enroll, reenroll, gencrl, idemix/cri, identities, register, revoke, idemix/credential, identities/{id}. ",
-			"status_code": "Http status code. https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-		},
+		Namespace:    "api_request",
+		Subsystem:    "",
+		Name:         "count",
+		Help:         "Number of requests made to an API",
+		LabelNames:   []string{"ca_name", "api_name", "status_code"},
 		StatsdFormat: "%{#fqname}.%{ca_name}.%{api_name}.%{status_code}",
 	}
 
 	// APIDurationOpts define the duration opts for server APIs
 	APIDurationOpts = metrics.HistogramOpts{
-		Namespace:  "api_request",
-		Subsystem:  "",
-		Name:       "duration",
-		Help:       "Time taken in seconds for the request to an API to be completed",
-		LabelNames: []string{"ca_name", "api_name", "status_code"},
-		LabelHelp: map[string]string{
-			"api_name":    "example api_names: affiliations/{affiliation}, affiliations, certificates, enroll, reenroll, gencrl, idemix/cri, identities, register, revoke, idemix/credential, identities/{id}. ",
-			"status_code": "Http status code. https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-		},
+		Namespace:    "api_request",
+		Subsystem:    "",
+		Name:         "duration",
+		Help:         "Time taken in seconds for the request to an API to be completed",
+		LabelNames:   []string{"ca_name", "api_name", "status_code"},
 		StatsdFormat: "%{#fqname}.%{ca_name}.%{api_name}.%{status_code}",
 	}
 )

--- a/vendor/github.com/hyperledger/fabric/common/metrics/gendoc/options.go
+++ b/vendor/github.com/hyperledger/fabric/common/metrics/gendoc/options.go
@@ -44,7 +44,7 @@ func FileOptions(f *ast.File) ([]interface{}, error) {
 
 	// If the file contains gendoc:ignore, ignore the file
 	for _, c := range f.Comments {
-		if strings.Contains(c.Text(), "gendoc:ignore") {
+		if strings.Index(c.Text(), "gendoc:ignore") != -1 {
 			return nil, nil
 		}
 	}
@@ -148,15 +148,6 @@ func populateOption(lit *ast.CompositeLit, target interface{}) (interface{}, err
 			// ignored
 			case "Buckets":
 
-			// map[string]string
-			case "LabelHelp":
-				labelHelp, err := asStringMap(kv.Value.(*ast.CompositeLit))
-				if err != nil {
-					return nil, err
-				}
-				labelHelpValue := reflect.ValueOf(labelHelp)
-				field.Set(labelHelpValue)
-
 			// slice of strings
 			case "LabelNames":
 				labelNames, err := stringSlice(kv.Value.(*ast.CompositeLit))
@@ -195,23 +186,4 @@ func stringSlice(lit *ast.CompositeLit) ([]string, error) {
 	}
 
 	return slice, nil
-}
-
-func asStringMap(lit *ast.CompositeLit) (map[string]string, error) {
-	m := map[string]string{}
-
-	for _, elem := range lit.Elts {
-		elem := elem.(*ast.KeyValueExpr)
-		key, err := strconv.Unquote(elem.Key.(*ast.BasicLit).Value)
-		if err != nil {
-			return nil, err
-		}
-		value, err := strconv.Unquote(elem.Value.(*ast.BasicLit).Value)
-		if err != nil {
-			return nil, err
-		}
-		m[key] = value
-	}
-
-	return m, nil
 }

--- a/vendor/github.com/hyperledger/fabric/common/metrics/metricsfakes/counter.go
+++ b/vendor/github.com/hyperledger/fabric/common/metrics/metricsfakes/counter.go
@@ -8,15 +8,10 @@ import (
 )
 
 type Counter struct {
-	AddStub        func(float64)
-	addMutex       sync.RWMutex
-	addArgsForCall []struct {
-		arg1 float64
-	}
-	WithStub        func(...string) metrics.Counter
+	WithStub        func(labelValues ...string) metrics.Counter
 	withMutex       sync.RWMutex
 	withArgsForCall []struct {
-		arg1 []string
+		labelValues []string
 	}
 	withReturns struct {
 		result1 metrics.Counter
@@ -24,57 +19,30 @@ type Counter struct {
 	withReturnsOnCall map[int]struct {
 		result1 metrics.Counter
 	}
+	AddStub        func(delta float64)
+	addMutex       sync.RWMutex
+	addArgsForCall []struct {
+		delta float64
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Counter) Add(arg1 float64) {
-	fake.addMutex.Lock()
-	fake.addArgsForCall = append(fake.addArgsForCall, struct {
-		arg1 float64
-	}{arg1})
-	fake.recordInvocation("Add", []interface{}{arg1})
-	fake.addMutex.Unlock()
-	if fake.AddStub != nil {
-		fake.AddStub(arg1)
-	}
-}
-
-func (fake *Counter) AddCallCount() int {
-	fake.addMutex.RLock()
-	defer fake.addMutex.RUnlock()
-	return len(fake.addArgsForCall)
-}
-
-func (fake *Counter) AddCalls(stub func(float64)) {
-	fake.addMutex.Lock()
-	defer fake.addMutex.Unlock()
-	fake.AddStub = stub
-}
-
-func (fake *Counter) AddArgsForCall(i int) float64 {
-	fake.addMutex.RLock()
-	defer fake.addMutex.RUnlock()
-	argsForCall := fake.addArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *Counter) With(arg1 ...string) metrics.Counter {
+func (fake *Counter) With(labelValues ...string) metrics.Counter {
 	fake.withMutex.Lock()
 	ret, specificReturn := fake.withReturnsOnCall[len(fake.withArgsForCall)]
 	fake.withArgsForCall = append(fake.withArgsForCall, struct {
-		arg1 []string
-	}{arg1})
-	fake.recordInvocation("With", []interface{}{arg1})
+		labelValues []string
+	}{labelValues})
+	fake.recordInvocation("With", []interface{}{labelValues})
 	fake.withMutex.Unlock()
 	if fake.WithStub != nil {
-		return fake.WithStub(arg1...)
+		return fake.WithStub(labelValues...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.withReturns
-	return fakeReturns.result1
+	return fake.withReturns.result1
 }
 
 func (fake *Counter) WithCallCount() int {
@@ -83,22 +51,13 @@ func (fake *Counter) WithCallCount() int {
 	return len(fake.withArgsForCall)
 }
 
-func (fake *Counter) WithCalls(stub func(...string) metrics.Counter) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
-	fake.WithStub = stub
-}
-
 func (fake *Counter) WithArgsForCall(i int) []string {
 	fake.withMutex.RLock()
 	defer fake.withMutex.RUnlock()
-	argsForCall := fake.withArgsForCall[i]
-	return argsForCall.arg1
+	return fake.withArgsForCall[i].labelValues
 }
 
 func (fake *Counter) WithReturns(result1 metrics.Counter) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
 	fake.WithStub = nil
 	fake.withReturns = struct {
 		result1 metrics.Counter
@@ -106,8 +65,6 @@ func (fake *Counter) WithReturns(result1 metrics.Counter) {
 }
 
 func (fake *Counter) WithReturnsOnCall(i int, result1 metrics.Counter) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
 	fake.WithStub = nil
 	if fake.withReturnsOnCall == nil {
 		fake.withReturnsOnCall = make(map[int]struct {
@@ -119,13 +76,37 @@ func (fake *Counter) WithReturnsOnCall(i int, result1 metrics.Counter) {
 	}{result1}
 }
 
+func (fake *Counter) Add(delta float64) {
+	fake.addMutex.Lock()
+	fake.addArgsForCall = append(fake.addArgsForCall, struct {
+		delta float64
+	}{delta})
+	fake.recordInvocation("Add", []interface{}{delta})
+	fake.addMutex.Unlock()
+	if fake.AddStub != nil {
+		fake.AddStub(delta)
+	}
+}
+
+func (fake *Counter) AddCallCount() int {
+	fake.addMutex.RLock()
+	defer fake.addMutex.RUnlock()
+	return len(fake.addArgsForCall)
+}
+
+func (fake *Counter) AddArgsForCall(i int) float64 {
+	fake.addMutex.RLock()
+	defer fake.addMutex.RUnlock()
+	return fake.addArgsForCall[i].delta
+}
+
 func (fake *Counter) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.addMutex.RLock()
-	defer fake.addMutex.RUnlock()
 	fake.withMutex.RLock()
 	defer fake.withMutex.RUnlock()
+	fake.addMutex.RLock()
+	defer fake.addMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/vendor/github.com/hyperledger/fabric/common/metrics/metricsfakes/gauge.go
+++ b/vendor/github.com/hyperledger/fabric/common/metrics/metricsfakes/gauge.go
@@ -8,20 +8,10 @@ import (
 )
 
 type Gauge struct {
-	AddStub        func(float64)
-	addMutex       sync.RWMutex
-	addArgsForCall []struct {
-		arg1 float64
-	}
-	SetStub        func(float64)
-	setMutex       sync.RWMutex
-	setArgsForCall []struct {
-		arg1 float64
-	}
-	WithStub        func(...string) metrics.Gauge
+	WithStub        func(labelValues ...string) metrics.Gauge
 	withMutex       sync.RWMutex
 	withArgsForCall []struct {
-		arg1 []string
+		labelValues []string
 	}
 	withReturns struct {
 		result1 metrics.Gauge
@@ -29,88 +19,35 @@ type Gauge struct {
 	withReturnsOnCall map[int]struct {
 		result1 metrics.Gauge
 	}
+	AddStub        func(delta float64)
+	addMutex       sync.RWMutex
+	addArgsForCall []struct {
+		delta float64
+	}
+	SetStub        func(value float64)
+	setMutex       sync.RWMutex
+	setArgsForCall []struct {
+		value float64
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Gauge) Add(arg1 float64) {
-	fake.addMutex.Lock()
-	fake.addArgsForCall = append(fake.addArgsForCall, struct {
-		arg1 float64
-	}{arg1})
-	fake.recordInvocation("Add", []interface{}{arg1})
-	fake.addMutex.Unlock()
-	if fake.AddStub != nil {
-		fake.AddStub(arg1)
-	}
-}
-
-func (fake *Gauge) AddCallCount() int {
-	fake.addMutex.RLock()
-	defer fake.addMutex.RUnlock()
-	return len(fake.addArgsForCall)
-}
-
-func (fake *Gauge) AddCalls(stub func(float64)) {
-	fake.addMutex.Lock()
-	defer fake.addMutex.Unlock()
-	fake.AddStub = stub
-}
-
-func (fake *Gauge) AddArgsForCall(i int) float64 {
-	fake.addMutex.RLock()
-	defer fake.addMutex.RUnlock()
-	argsForCall := fake.addArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *Gauge) Set(arg1 float64) {
-	fake.setMutex.Lock()
-	fake.setArgsForCall = append(fake.setArgsForCall, struct {
-		arg1 float64
-	}{arg1})
-	fake.recordInvocation("Set", []interface{}{arg1})
-	fake.setMutex.Unlock()
-	if fake.SetStub != nil {
-		fake.SetStub(arg1)
-	}
-}
-
-func (fake *Gauge) SetCallCount() int {
-	fake.setMutex.RLock()
-	defer fake.setMutex.RUnlock()
-	return len(fake.setArgsForCall)
-}
-
-func (fake *Gauge) SetCalls(stub func(float64)) {
-	fake.setMutex.Lock()
-	defer fake.setMutex.Unlock()
-	fake.SetStub = stub
-}
-
-func (fake *Gauge) SetArgsForCall(i int) float64 {
-	fake.setMutex.RLock()
-	defer fake.setMutex.RUnlock()
-	argsForCall := fake.setArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *Gauge) With(arg1 ...string) metrics.Gauge {
+func (fake *Gauge) With(labelValues ...string) metrics.Gauge {
 	fake.withMutex.Lock()
 	ret, specificReturn := fake.withReturnsOnCall[len(fake.withArgsForCall)]
 	fake.withArgsForCall = append(fake.withArgsForCall, struct {
-		arg1 []string
-	}{arg1})
-	fake.recordInvocation("With", []interface{}{arg1})
+		labelValues []string
+	}{labelValues})
+	fake.recordInvocation("With", []interface{}{labelValues})
 	fake.withMutex.Unlock()
 	if fake.WithStub != nil {
-		return fake.WithStub(arg1...)
+		return fake.WithStub(labelValues...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.withReturns
-	return fakeReturns.result1
+	return fake.withReturns.result1
 }
 
 func (fake *Gauge) WithCallCount() int {
@@ -119,22 +56,13 @@ func (fake *Gauge) WithCallCount() int {
 	return len(fake.withArgsForCall)
 }
 
-func (fake *Gauge) WithCalls(stub func(...string) metrics.Gauge) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
-	fake.WithStub = stub
-}
-
 func (fake *Gauge) WithArgsForCall(i int) []string {
 	fake.withMutex.RLock()
 	defer fake.withMutex.RUnlock()
-	argsForCall := fake.withArgsForCall[i]
-	return argsForCall.arg1
+	return fake.withArgsForCall[i].labelValues
 }
 
 func (fake *Gauge) WithReturns(result1 metrics.Gauge) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
 	fake.WithStub = nil
 	fake.withReturns = struct {
 		result1 metrics.Gauge
@@ -142,8 +70,6 @@ func (fake *Gauge) WithReturns(result1 metrics.Gauge) {
 }
 
 func (fake *Gauge) WithReturnsOnCall(i int, result1 metrics.Gauge) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
 	fake.WithStub = nil
 	if fake.withReturnsOnCall == nil {
 		fake.withReturnsOnCall = make(map[int]struct {
@@ -155,15 +81,63 @@ func (fake *Gauge) WithReturnsOnCall(i int, result1 metrics.Gauge) {
 	}{result1}
 }
 
+func (fake *Gauge) Add(delta float64) {
+	fake.addMutex.Lock()
+	fake.addArgsForCall = append(fake.addArgsForCall, struct {
+		delta float64
+	}{delta})
+	fake.recordInvocation("Add", []interface{}{delta})
+	fake.addMutex.Unlock()
+	if fake.AddStub != nil {
+		fake.AddStub(delta)
+	}
+}
+
+func (fake *Gauge) AddCallCount() int {
+	fake.addMutex.RLock()
+	defer fake.addMutex.RUnlock()
+	return len(fake.addArgsForCall)
+}
+
+func (fake *Gauge) AddArgsForCall(i int) float64 {
+	fake.addMutex.RLock()
+	defer fake.addMutex.RUnlock()
+	return fake.addArgsForCall[i].delta
+}
+
+func (fake *Gauge) Set(value float64) {
+	fake.setMutex.Lock()
+	fake.setArgsForCall = append(fake.setArgsForCall, struct {
+		value float64
+	}{value})
+	fake.recordInvocation("Set", []interface{}{value})
+	fake.setMutex.Unlock()
+	if fake.SetStub != nil {
+		fake.SetStub(value)
+	}
+}
+
+func (fake *Gauge) SetCallCount() int {
+	fake.setMutex.RLock()
+	defer fake.setMutex.RUnlock()
+	return len(fake.setArgsForCall)
+}
+
+func (fake *Gauge) SetArgsForCall(i int) float64 {
+	fake.setMutex.RLock()
+	defer fake.setMutex.RUnlock()
+	return fake.setArgsForCall[i].value
+}
+
 func (fake *Gauge) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.withMutex.RLock()
+	defer fake.withMutex.RUnlock()
 	fake.addMutex.RLock()
 	defer fake.addMutex.RUnlock()
 	fake.setMutex.RLock()
 	defer fake.setMutex.RUnlock()
-	fake.withMutex.RLock()
-	defer fake.withMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/vendor/github.com/hyperledger/fabric/common/metrics/metricsfakes/histogram.go
+++ b/vendor/github.com/hyperledger/fabric/common/metrics/metricsfakes/histogram.go
@@ -8,15 +8,10 @@ import (
 )
 
 type Histogram struct {
-	ObserveStub        func(float64)
-	observeMutex       sync.RWMutex
-	observeArgsForCall []struct {
-		arg1 float64
-	}
-	WithStub        func(...string) metrics.Histogram
+	WithStub        func(labelValues ...string) metrics.Histogram
 	withMutex       sync.RWMutex
 	withArgsForCall []struct {
-		arg1 []string
+		labelValues []string
 	}
 	withReturns struct {
 		result1 metrics.Histogram
@@ -24,57 +19,30 @@ type Histogram struct {
 	withReturnsOnCall map[int]struct {
 		result1 metrics.Histogram
 	}
+	ObserveStub        func(value float64)
+	observeMutex       sync.RWMutex
+	observeArgsForCall []struct {
+		value float64
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *Histogram) Observe(arg1 float64) {
-	fake.observeMutex.Lock()
-	fake.observeArgsForCall = append(fake.observeArgsForCall, struct {
-		arg1 float64
-	}{arg1})
-	fake.recordInvocation("Observe", []interface{}{arg1})
-	fake.observeMutex.Unlock()
-	if fake.ObserveStub != nil {
-		fake.ObserveStub(arg1)
-	}
-}
-
-func (fake *Histogram) ObserveCallCount() int {
-	fake.observeMutex.RLock()
-	defer fake.observeMutex.RUnlock()
-	return len(fake.observeArgsForCall)
-}
-
-func (fake *Histogram) ObserveCalls(stub func(float64)) {
-	fake.observeMutex.Lock()
-	defer fake.observeMutex.Unlock()
-	fake.ObserveStub = stub
-}
-
-func (fake *Histogram) ObserveArgsForCall(i int) float64 {
-	fake.observeMutex.RLock()
-	defer fake.observeMutex.RUnlock()
-	argsForCall := fake.observeArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *Histogram) With(arg1 ...string) metrics.Histogram {
+func (fake *Histogram) With(labelValues ...string) metrics.Histogram {
 	fake.withMutex.Lock()
 	ret, specificReturn := fake.withReturnsOnCall[len(fake.withArgsForCall)]
 	fake.withArgsForCall = append(fake.withArgsForCall, struct {
-		arg1 []string
-	}{arg1})
-	fake.recordInvocation("With", []interface{}{arg1})
+		labelValues []string
+	}{labelValues})
+	fake.recordInvocation("With", []interface{}{labelValues})
 	fake.withMutex.Unlock()
 	if fake.WithStub != nil {
-		return fake.WithStub(arg1...)
+		return fake.WithStub(labelValues...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.withReturns
-	return fakeReturns.result1
+	return fake.withReturns.result1
 }
 
 func (fake *Histogram) WithCallCount() int {
@@ -83,22 +51,13 @@ func (fake *Histogram) WithCallCount() int {
 	return len(fake.withArgsForCall)
 }
 
-func (fake *Histogram) WithCalls(stub func(...string) metrics.Histogram) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
-	fake.WithStub = stub
-}
-
 func (fake *Histogram) WithArgsForCall(i int) []string {
 	fake.withMutex.RLock()
 	defer fake.withMutex.RUnlock()
-	argsForCall := fake.withArgsForCall[i]
-	return argsForCall.arg1
+	return fake.withArgsForCall[i].labelValues
 }
 
 func (fake *Histogram) WithReturns(result1 metrics.Histogram) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
 	fake.WithStub = nil
 	fake.withReturns = struct {
 		result1 metrics.Histogram
@@ -106,8 +65,6 @@ func (fake *Histogram) WithReturns(result1 metrics.Histogram) {
 }
 
 func (fake *Histogram) WithReturnsOnCall(i int, result1 metrics.Histogram) {
-	fake.withMutex.Lock()
-	defer fake.withMutex.Unlock()
 	fake.WithStub = nil
 	if fake.withReturnsOnCall == nil {
 		fake.withReturnsOnCall = make(map[int]struct {
@@ -119,13 +76,37 @@ func (fake *Histogram) WithReturnsOnCall(i int, result1 metrics.Histogram) {
 	}{result1}
 }
 
+func (fake *Histogram) Observe(value float64) {
+	fake.observeMutex.Lock()
+	fake.observeArgsForCall = append(fake.observeArgsForCall, struct {
+		value float64
+	}{value})
+	fake.recordInvocation("Observe", []interface{}{value})
+	fake.observeMutex.Unlock()
+	if fake.ObserveStub != nil {
+		fake.ObserveStub(value)
+	}
+}
+
+func (fake *Histogram) ObserveCallCount() int {
+	fake.observeMutex.RLock()
+	defer fake.observeMutex.RUnlock()
+	return len(fake.observeArgsForCall)
+}
+
+func (fake *Histogram) ObserveArgsForCall(i int) float64 {
+	fake.observeMutex.RLock()
+	defer fake.observeMutex.RUnlock()
+	return fake.observeArgsForCall[i].value
+}
+
 func (fake *Histogram) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.observeMutex.RLock()
-	defer fake.observeMutex.RUnlock()
 	fake.withMutex.RLock()
 	defer fake.withMutex.RUnlock()
+	fake.observeMutex.RLock()
+	defer fake.observeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/vendor/github.com/hyperledger/fabric/common/metrics/metricsfakes/provider.go
+++ b/vendor/github.com/hyperledger/fabric/common/metrics/metricsfakes/provider.go
@@ -59,8 +59,7 @@ func (fake *Provider) NewCounter(arg1 metrics.CounterOpts) metrics.Counter {
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newCounterReturns
-	return fakeReturns.result1
+	return fake.newCounterReturns.result1
 }
 
 func (fake *Provider) NewCounterCallCount() int {
@@ -69,22 +68,13 @@ func (fake *Provider) NewCounterCallCount() int {
 	return len(fake.newCounterArgsForCall)
 }
 
-func (fake *Provider) NewCounterCalls(stub func(metrics.CounterOpts) metrics.Counter) {
-	fake.newCounterMutex.Lock()
-	defer fake.newCounterMutex.Unlock()
-	fake.NewCounterStub = stub
-}
-
 func (fake *Provider) NewCounterArgsForCall(i int) metrics.CounterOpts {
 	fake.newCounterMutex.RLock()
 	defer fake.newCounterMutex.RUnlock()
-	argsForCall := fake.newCounterArgsForCall[i]
-	return argsForCall.arg1
+	return fake.newCounterArgsForCall[i].arg1
 }
 
 func (fake *Provider) NewCounterReturns(result1 metrics.Counter) {
-	fake.newCounterMutex.Lock()
-	defer fake.newCounterMutex.Unlock()
 	fake.NewCounterStub = nil
 	fake.newCounterReturns = struct {
 		result1 metrics.Counter
@@ -92,8 +82,6 @@ func (fake *Provider) NewCounterReturns(result1 metrics.Counter) {
 }
 
 func (fake *Provider) NewCounterReturnsOnCall(i int, result1 metrics.Counter) {
-	fake.newCounterMutex.Lock()
-	defer fake.newCounterMutex.Unlock()
 	fake.NewCounterStub = nil
 	if fake.newCounterReturnsOnCall == nil {
 		fake.newCounterReturnsOnCall = make(map[int]struct {
@@ -119,8 +107,7 @@ func (fake *Provider) NewGauge(arg1 metrics.GaugeOpts) metrics.Gauge {
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newGaugeReturns
-	return fakeReturns.result1
+	return fake.newGaugeReturns.result1
 }
 
 func (fake *Provider) NewGaugeCallCount() int {
@@ -129,22 +116,13 @@ func (fake *Provider) NewGaugeCallCount() int {
 	return len(fake.newGaugeArgsForCall)
 }
 
-func (fake *Provider) NewGaugeCalls(stub func(metrics.GaugeOpts) metrics.Gauge) {
-	fake.newGaugeMutex.Lock()
-	defer fake.newGaugeMutex.Unlock()
-	fake.NewGaugeStub = stub
-}
-
 func (fake *Provider) NewGaugeArgsForCall(i int) metrics.GaugeOpts {
 	fake.newGaugeMutex.RLock()
 	defer fake.newGaugeMutex.RUnlock()
-	argsForCall := fake.newGaugeArgsForCall[i]
-	return argsForCall.arg1
+	return fake.newGaugeArgsForCall[i].arg1
 }
 
 func (fake *Provider) NewGaugeReturns(result1 metrics.Gauge) {
-	fake.newGaugeMutex.Lock()
-	defer fake.newGaugeMutex.Unlock()
 	fake.NewGaugeStub = nil
 	fake.newGaugeReturns = struct {
 		result1 metrics.Gauge
@@ -152,8 +130,6 @@ func (fake *Provider) NewGaugeReturns(result1 metrics.Gauge) {
 }
 
 func (fake *Provider) NewGaugeReturnsOnCall(i int, result1 metrics.Gauge) {
-	fake.newGaugeMutex.Lock()
-	defer fake.newGaugeMutex.Unlock()
 	fake.NewGaugeStub = nil
 	if fake.newGaugeReturnsOnCall == nil {
 		fake.newGaugeReturnsOnCall = make(map[int]struct {
@@ -179,8 +155,7 @@ func (fake *Provider) NewHistogram(arg1 metrics.HistogramOpts) metrics.Histogram
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.newHistogramReturns
-	return fakeReturns.result1
+	return fake.newHistogramReturns.result1
 }
 
 func (fake *Provider) NewHistogramCallCount() int {
@@ -189,22 +164,13 @@ func (fake *Provider) NewHistogramCallCount() int {
 	return len(fake.newHistogramArgsForCall)
 }
 
-func (fake *Provider) NewHistogramCalls(stub func(metrics.HistogramOpts) metrics.Histogram) {
-	fake.newHistogramMutex.Lock()
-	defer fake.newHistogramMutex.Unlock()
-	fake.NewHistogramStub = stub
-}
-
 func (fake *Provider) NewHistogramArgsForCall(i int) metrics.HistogramOpts {
 	fake.newHistogramMutex.RLock()
 	defer fake.newHistogramMutex.RUnlock()
-	argsForCall := fake.newHistogramArgsForCall[i]
-	return argsForCall.arg1
+	return fake.newHistogramArgsForCall[i].arg1
 }
 
 func (fake *Provider) NewHistogramReturns(result1 metrics.Histogram) {
-	fake.newHistogramMutex.Lock()
-	defer fake.newHistogramMutex.Unlock()
 	fake.NewHistogramStub = nil
 	fake.newHistogramReturns = struct {
 		result1 metrics.Histogram
@@ -212,8 +178,6 @@ func (fake *Provider) NewHistogramReturns(result1 metrics.Histogram) {
 }
 
 func (fake *Provider) NewHistogramReturnsOnCall(i int, result1 metrics.Histogram) {
-	fake.newHistogramMutex.Lock()
-	defer fake.newHistogramMutex.Unlock()
 	fake.NewHistogramStub = nil
 	if fake.newHistogramReturnsOnCall == nil {
 		fake.newHistogramReturnsOnCall = make(map[int]struct {

--- a/vendor/github.com/hyperledger/fabric/common/metrics/provider.go
+++ b/vendor/github.com/hyperledger/fabric/common/metrics/provider.go
@@ -46,10 +46,6 @@ type CounterOpts struct {
 	// of these label names.
 	LabelNames []string
 
-	// LabelHelp provides help information for labels. When set, this information
-	// will be used to populate the documentation.
-	LabelHelp map[string]string
-
 	// StatsdFormat determines how the fully-qualified statsd bucket name is
 	// constructed from Namespace, Subsystem, Name, and Labels. This is done by
 	// including field references in `%{reference}` escape sequences.
@@ -96,10 +92,6 @@ type GaugeOpts struct {
 	// metric. When a metric is recorded, label values must be provided for each
 	// of these label names.
 	LabelNames []string
-
-	// LabelHelp provides help information for labels. When set, this information
-	// will be used to populate the documentation.
-	LabelHelp map[string]string
 
 	// StatsdFormat determines how the fully-qualified statsd bucket name is
 	// constructed from Namespace, Subsystem, Name, and Labels. This is done by
@@ -148,10 +140,6 @@ type HistogramOpts struct {
 	// metric. When a metric is recorded, label values must be provided for each
 	// of these label names.
 	LabelNames []string
-
-	// LabelHelp provides help information for labels. When set, this information
-	// will be used to populate the documentation.
-	LabelHelp map[string]string
 
 	// StatsdFormat determines how the fully-qualified statsd bucket name is
 	// constructed from Namespace, Subsystem, Name, and Labels. This is done by

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -669,13 +669,13 @@
 			"versionExact": "release-1.4"
 		},
 		{
-			"checksumSHA1": "YUhMkV0DBrplcqK/TTbZbp1CNB4=",
+			"checksumSHA1": "cOiPYqF62i2lLRxi2TAaAY8ze0I=",
 			"path": "github.com/hyperledger/fabric/common/metrics",
-			"revision": "77bafd68ab02c0a7cd4f4f06d5b718fd57ac877a",
-			"revisionTime": "2020-04-13T01:26:49Z",
+			"revision": "1f0a0dd5316310d299a02f0588db3f7ec50c965e",
+			"revisionTime": "2020-04-08T13:26:44Z",
 			"tree": true,
-			"version": "release-2.0",
-			"versionExact": "release-2.0"
+			"version": "release-1.4",
+			"versionExact": "release-1.4"
 		},
 		{
 			"checksumSHA1": "PZEB7eAHAev0KuBWBfDvfGGIO9c=",


### PR DESCRIPTION
This allows us to pull the metrics packages in from fabric release-1.4; that means all code in in the CA is coming from release-1.4.