### PR TITLE
Remove release triggers from master AZP file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.csr
 *.der
 /release/darwin-amd64

--- a/ci/azp-pipeline.yml
+++ b/ci/azp-pipeline.yml
@@ -5,12 +5,8 @@
 name: $(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rrr)
 trigger:
 - master
-- release-2.*
-- release-1.4
 pr:
 - master
-- release-2.*
-- release-1.4
 
 variables:
   GOPATH: $(Agent.BuildDirectory)/go


### PR DESCRIPTION
This change removes the explicit triggering of the release branches from the master branch AZP file

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
