### PR TITLE
Add operations guide to the toc in the release-1.4  branch

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,8 +6,10 @@ This build of the docs is from the "|version|" branch
 .. toctree::
    :maxdepth: 2
    :caption: Getting Started
- 
+
    users-guide
+   
+   operations_guide
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
Signed-off-by: pama-ibm <pama@ibm.com>

Adding the operations guide to the toc so we can backport the CA Deployment Guide to the release-1.4 branch

#### Type of change

- Documentation update


