### PR TITLE
Update CI publish target

### DIFF
--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -36,7 +36,7 @@ stages:
             displayName: Checkout Fabric CA Code
           - script: make dist/$(TARGET)
             displayName: Compile Binary and Create Tarball
-          - publish: release/$(TARGET)/bin/hyperledger-fabric-ca-$(TARGET)-$(RELEASE).tar.gz
+          - publish: release/$(TARGET)/hyperledger-fabric-ca-$(TARGET)-$(RELEASE).tar.gz
             artifact: hyperledger-fabric-ca-$(TARGET)-$(RELEASE).tar.gz
             displayName: Publish Release Artifact
 

--- a/scripts/check_license
+++ b/scripts/check_license
@@ -20,6 +20,7 @@ function filterExcludedFiles {
 		| grep -v "swagger/" \
 		| grep -v "^LICENSE$" \
 		| grep -v "\.png$" \
+		| grep -v "\.pptx$" \
 		| grep -v "\.rst$" \
 		| grep -v "\.txt$" \
 		| grep -v "\.pem$" \


### PR DESCRIPTION
Simple change, the `dist` make target now packages the bin directory, so we don't need to step into the bin directory to collect the tarball

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
