### PR TITLE
Retire dormant Fabric CA maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,11 +3,8 @@ Maintainers
 
 | Name | GitHub | Chat | email |
 |------|--------|------|-------|
-| Chris Ferris | christo4ferris | cbf | <chris.ferris@gmail.com> |
 | Dave Enyeart | denyeart | dave.enyeart | <enyeart@us.ibm.com> |
 | Gari Singh | mastersingh24 | mastersingh24 | <gari.r.singh@gmail.com> |
-| Jonathan Levi | hacera | JonathanLevi | <jonathan@hacera.com> |
-| Keith Smith | smithbk | smithbk | <bksmith@us.ibm.com> |
 | Matthew Sykes | sykesm | sykesm | <sykesmat@us.ibm.com> |
 | Saad Karim | saad-karim | skarim | <skarim@us.ibm.com> |
 
@@ -22,6 +19,17 @@ Documentation Maintainers
 | Joe Alewine | joealewine | joe-alewine | <joe.alewine@ibm.com> |
 | Nikhil Gupta | nikhil550 | nikhilgupta | <negupta@us.ibm.com> |
 | Pam Andrejko | pamandrejko | pandrejko | <pama@ibm.com> |
+
+
+Retired Maintainers
+===================
+
+| Name | GitHub | Chat | email |
+|------|--------|------|-------|
+| Chris Ferris | christo4ferris | cbf | <chris.ferris@gmail.com> |
+| Jonathan Levi | hacera | JonathanLevi | <jonathan@hacera.com> |
+| Keith Smith | smithbk | smithbk | <bksmith@us.ibm.com> |
+
 
 Also: Please see the [Release Manager section](https://github.com/hyperledger/fabric/blob/master/MAINTAINERS.md)
 


### PR DESCRIPTION
Retire maintainers that have been inactive for the last 3 months:
Chris Ferris
Jonathan Levi
Keith Smith

Note:
"A maintainer removed for inactivity should be restored following a
sustained resumption of contributions and reviews (a month or more)
demonstrating a renewed commitment to the project."

Signed-off-by: David Enyeart <enyeart@us.ibm.com>