### PR TITLE
[FABC-829] Add hf.AffiliationMgr and hf.GenCRL attributes to migrated registrar users

### DIFF
--- a/lib/server/user/user_test.go
+++ b/lib/server/user/user_test.go
@@ -432,13 +432,27 @@ var _ = Describe("user", func() {
 	})
 
 	Context("migrate", func() {
-		It("adds new attribute to user", func() {
+		It("adds new attributes to user", func() {
+			_, err := u.GetAttribute("hf.Registrar.Attributes")
+			Expect(err).To(HaveOccurred())
+			_, err = u.GetAttribute("hf.AffiliationMgr")
+			Expect(err).To(HaveOccurred())
+			_, err = u.GetAttribute("hf.GenCRL")
+			Expect(err).To(HaveOccurred())
+
 			mockResult.RowsAffectedReturns(int64(1), nil)
 			mockUserDB.ExecReturns(mockResult, nil)
-			err := u.Migrate(mockUserDB)
+			err = u.Migrate(mockUserDB)
 			Expect(err).NotTo(HaveOccurred())
-			_, err = u.GetAttribute("hf.Registrar.Attributes")
+			val, err := u.GetAttribute("hf.Registrar.Attributes")
 			Expect(err).NotTo(HaveOccurred())
+			Expect(val.Value).To(Equal("*"))
+			val, err = u.GetAttribute("hf.AffiliationMgr")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val.Value).To(Equal("true"))
+			val, err = u.GetAttribute("hf.GenCRL")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val.Value).To(Equal("true"))
 		})
 	})
 


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Since the initial release of Fabric CA, the list of reserved attributes (hf.*) has grown. A certain subset of users upon migration from an older version of CA to a newer one should be given any newly introduced attributes that have been added in the new release.

#### Related issues

[FABC-829](https://jira.hyperledger.org/browse/FABC-829)