### PR TITLE
Remove unnecessary docker make vars and doc update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,9 @@ build/image/fabric-ca/$(DUMMY):
 		--build-arg GO_TAGS=pkcs11 \
 		--build-arg GO_LDFLAGS="${DOCKER_GO_LDFLAGS}" \
 		--build-arg ALPINE_VER=${ALPINE_VER} \
-		-t $(BASE_DOCKER_NS)/$(TARGET) .
-	docker tag $(BASE_DOCKER_NS)/$(TARGET) \
-		$(DOCKER_NS)/$(TARGET):$(BASE_VERSION)
-	docker tag $(BASE_DOCKER_NS)/$(TARGET) \
-		$(DOCKER_NS)/$(TARGET):$(DOCKER_TAG)
+		-t $(DOCKER_NS)/$(TARGET) .
+	docker tag $(DOCKER_NS)/$(TARGET) $(DOCKER_NS)/$(TARGET):$(BASE_VERSION)
+	docker tag $(DOCKER_NS)/$(TARGET) $(DOCKER_NS)/$(TARGET):$(DOCKER_TAG)
 	@touch $@
 
 build/image/fabric-ca-fvt/$(DUMMY):
@@ -144,7 +142,7 @@ build/image/fabric-ca-fvt/$(DUMMY):
 		--build-arg GO_TAGS=pkcs11 \
 		--build-arg GO_LDFLAGS="${DOCKER_GO_LDFLAGS}" \
 		--build-arg PG_VER=${PG_VER} \
-		-t $(BASE_DOCKER_NS)/$(TARGET) .
+		-t $(DOCKER_NS)/$(TARGET) .
 	@touch $@
 
 
@@ -181,7 +179,6 @@ fvt-tests: docker-clean docker-fvt
 %-docker-clean:
 	$(eval TARGET = ${patsubst %-docker-clean,%,${@}})
 	-docker images -q $(DOCKER_NS)/$(TARGET):latest | xargs -I '{}' docker rmi -f '{}'
-	-docker images -q $(NEXUS_URL)/*:$(STABLE_TAG) | xargs -I '{}' docker rmi -f '{}'
 	-@rm -rf build/image/$(TARGET) ||:
 
 docker-clean: $(patsubst %,%-docker-clean, $(IMAGES) $(PROJECT_NAME)-fvt)

--- a/docker-env.mk
+++ b/docker-env.mk
@@ -1,57 +1,29 @@
 # Copyright London Stock Exchange Group All Rights Reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-ifneq ($(shell uname),Darwin)
-DOCKER_RUN_FLAGS=--user=$(shell id -u)
-endif
+# SPDX-License-Identifier: Apache-2.0
 
 ifneq ($(http_proxy),)
 DOCKER_BUILD_FLAGS+=--build-arg http_proxy=$(http_proxy)
-DOCKER_RUN_FLAGS+=-e http_proxy=$(http_proxy)
 endif
 ifneq ($(https_proxy),)
 DOCKER_BUILD_FLAGS+=--build-arg https_proxy=$(https_proxy)
-DOCKER_RUN_FLAGS+=-e https_proxy=$(https_proxy)
 endif
 ifneq ($(HTTP_PROXY),)
 DOCKER_BUILD_FLAGS+=--build-arg HTTP_PROXY=$(HTTP_PROXY)
-DOCKER_RUN_FLAGS+=-e HTTP_PROXY=$(HTTP_PROXY)
 endif
 ifneq ($(HTTPS_PROXY),)
 DOCKER_BUILD_FLAGS+=--build-arg HTTPS_PROXY=$(HTTPS_PROXY)
-DOCKER_RUN_FLAGS+=-e HTTPS_PROXY=$(HTTPS_PROXY)
 endif
 ifneq ($(no_proxy),)
 DOCKER_BUILD_FLAGS+=--build-arg no_proxy=$(no_proxy)
-DOCKER_RUN_FLAGS+=-e no_proxy=$(no_proxy)
 endif
 ifneq ($(NO_PROXY),)
 DOCKER_BUILD_FLAGS+=--build-arg NO_PROXY=$(NO_PROXY)
-DOCKER_RUN_FLAGS+=-e NO_PROXY=$(NO_PROXY)
 endif
-
-DRUN = docker run -i --rm $(DOCKER_RUN_FLAGS) \
-	-v $(abspath .):/opt/gopath/src/$(PKGNAME) \
-	-w /opt/gopath/src/$(PKGNAME)
 
 DBUILD = docker build $(DOCKER_BUILD_FLAGS)
 
-BASE_DOCKER_NS ?= hyperledger
-BASE_DOCKER_TAG=$(ARCH)-$(BASEIMAGE_RELEASE)
-
 DOCKER_NS ?= hyperledger
-NEXUS_URL ?= nexus3.hyperledger.org:10001/hyperledger
 DOCKER_TAG=$(ARCH)-$(PROJECT_VERSION)
 
 DOCKER_GO_LDFLAGS += $(GO_LDFLAGS)
@@ -83,6 +55,3 @@ DOCKER_GO_LDFLAGS += -linkmode external -extldflags '-lpthread'
 # file to differentiate different tags to fix FAB-1145
 #
 DUMMY = .dummy-$(DOCKER_TAG)
-
-
-

--- a/docs/source/users-guide.rst
+++ b/docs/source/users-guide.rst
@@ -184,19 +184,16 @@ Docker Hub
 
 Go to: https://hub.docker.com/r/hyperledger/fabric-ca/tags/
 
-Find the tag that matches the architecture and version of fabric-ca
-that you want to pull.
+Find the tag that matches the architecture and version of fabric-ca that you
+want to pull.
 
-Navigate to `$GOPATH/src/github.com/hyperledger/fabric-ca/docker/server`
-and open up docker-compose.yml in an editor.
-
-Change the `image` line to reflect the tag you found previously. The file
-may look like this for an x86 architecture for version beta.
+Create a `docker-compose.yml` file like the one below. Change the `image` line
+to reflect the tag you found previously.
 
 .. code:: yaml
 
     fabric-ca-server:
-      image: hyperledger/fabric-ca:x86_64-1.0.0-beta
+      image: hyperledger/fabric-ca:amd64-1.4.7
       container_name: fabric-ca-server
       ports:
         - "7054:7054"


### PR DESCRIPTION
- Remove references to Nexus from the `Makefile`
- Remove `BASE_DOCKER_*` variables from the `make` process
- Remove `DRUN` macro and related artifacts from the `make` process