### PR TITLE
Remove unused env vars in fabric-ca_setup.sh

### DIFF
--- a/scripts/fvt/fabric-ca_setup.sh
+++ b/scripts/fvt/fabric-ca_setup.sh
@@ -8,8 +8,6 @@
 FABRIC_CA="$GOPATH/src/github.com/hyperledger/fabric-ca"
 SCRIPTDIR="$FABRIC_CA/scripts/fvt"
 . $SCRIPTDIR/fabric-ca_utils
-GO_VER="1.7.1"
-ARCH="amd64"
 RC=0
 
 function usage() {


### PR DESCRIPTION
Really stale version of go was referenced in the script but, thankfully, it appears unused.