### PR TITLE
[FABC-913] Set a primary key to users table for SQLite

### DIFF
--- a/lib/dbaccessor_test.go
+++ b/lib/dbaccessor_test.go
@@ -330,7 +330,7 @@ func testInsertAndGetFilteredUsers(ta TestAccessor, t *testing.T) {
 			t.Errorf("Failed to get read row! error: %s", err)
 		}
 		// get the target user
-		if id.Name == insert.Name && id.Type == "client" {
+		if id.Name == "testTypesClient" && id.Type == "client" {
 			typesClientSuccessFlag = true
 		}
 	}
@@ -346,6 +346,7 @@ func testInsertAndGetFilteredUsers(ta TestAccessor, t *testing.T) {
 		t.Errorf("Error occured during insert query of group: %s, error: %s", "Bank1", err)
 	}
 	// change user info
+	insert.Name = "testTypesStar"
 	insert.Type = "*"
 	insert.Affiliation = "Bank1"
 	// insert user
@@ -367,7 +368,7 @@ func testInsertAndGetFilteredUsers(ta TestAccessor, t *testing.T) {
 			t.Errorf("Failed to get read row! error: %s", err)
 		}
 		// get the target user
-		if id.Affiliation == "Bank1" && id.Name == insert.Name {
+		if id.Affiliation == "Bank1" && id.Name == "testTypesStar" {
 			affiliationsTypeStarSuccessFlag = true
 		}
 	}
@@ -391,10 +392,10 @@ func testInsertAndGetFilteredUsers(ta TestAccessor, t *testing.T) {
 			t.Errorf("Failed to get read row! error: %s", err)
 		}
 		// get the target user
-		if id.Affiliation == "Bank1" && id.Name == insert.Name {
+		if id.Affiliation == "Bank1" && id.Name == "testTypesStar" {
 			affiliationsTypeStarSuccessFlag = true
 		}
-		if id.Name == insert.Name && id.Type == "client" {
+		if id.Name == "testTypesClient" && id.Type == "client" {
 			typesClientSuccessFlag = true
 		}
 	}

--- a/lib/server/db/sqlite/sqlite.go
+++ b/lib/server/db/sqlite/sqlite.go
@@ -135,7 +135,7 @@ func createAllSQLiteTables(tx Create, args ...interface{}) error {
 
 func createIdentityTable(tx Create) error {
 	log.Debug("Creating users table if it does not exist")
-	if _, err := tx.Exec("CreateUsersTable", "CREATE TABLE IF NOT EXISTS users (id VARCHAR(255), token bytea, type VARCHAR(256), affiliation VARCHAR(1024), attributes TEXT, state INTEGER,  max_enrollments INTEGER, level INTEGER DEFAULT 0, incorrect_password_attempts INTEGER DEFAULT 0)"); err != nil {
+	if _, err := tx.Exec("CreateUsersTable", "CREATE TABLE IF NOT EXISTS users (id VARCHAR(255), token bytea, type VARCHAR(256), affiliation VARCHAR(1024), attributes TEXT, state INTEGER, max_enrollments INTEGER, level INTEGER DEFAULT 0, incorrect_password_attempts INTEGER DEFAULT 0, PRIMARY KEY (id))"); err != nil {
 		return errors.Wrap(err, "Error creating users table")
 	}
 	return nil


### PR DESCRIPTION
This patch sets a primary key with `id` to `users` table for SQLite like the implementations of the other RDBs (MySQL, PostgreSQL).

The main reason is to prevent duplicate registration of the same ID depending on the timing.

#### Type of change

- Bug fix

#### Description

When using SQLite, duplicate registration of the same ID would occur depending on the timing. After that, the ID would not work. 

This is because the users table does not have the primary key `id`.
The implementations for other RDBs (MySQL, PostgreSQL) set `id` as the primary key in `users` table.

So, this patch sets a primary key with `id` to `users` table for SQLite.

#### Related issues

- https://jira.hyperledger.org/browse/FABC-913
