### PR TITLE
Bump Go and Alpine Versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 #   - vendor - vendors third-party packages
 
 PROJECT_NAME = fabric-ca
-ALPINE_VER ?= 3.11
+ALPINE_VER ?= 3.12
 DEBIAN_VER ?= stretch
 BASE_VERSION = 2.0.0
 PREV_VERSION = 2.0.0-alpha
@@ -54,7 +54,7 @@ PKGNAME = github.com/hyperledger/$(PROJECT_NAME)
 
 METADATA_VAR = Version=$(PROJECT_VERSION)
 
-GO_VER = 1.14.1
+GO_VER = 1.14.4
 GO_SOURCE := $(shell find . -name '*.go')
 GO_LDFLAGS = $(patsubst %,-X $(PKGNAME)/lib/metadata.%,$(METADATA_VAR))
 export GO_LDFLAGS

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-ca/build/tools:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.14.1
+  GOVER: 1.14.4
 
 jobs:
 - job: VerifyBuild


### PR DESCRIPTION
Bump Go to 1.14.4. This is also the first Go release to switch to alpine 3.12 with 1.14.3 being the last to support 3.11. Performing this update now will allow us to cross the alpine minor version barrier prior to our LTS release of 2.2 to give us time to test the stability of the release.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
