### PR TITLE
[FABC-912] Remove label and pin from logs

### DIFF
--- a/internal/pkg/util/configurebccsp.go
+++ b/internal/pkg/util/configurebccsp.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cloudflare/cfssl/log"
 	"github.com/hyperledger/fabric/bccsp/factory"
+	"github.com/hyperledger/fabric/bccsp/pkcs11"
 	"github.com/pkg/errors"
 )
 
@@ -59,8 +60,16 @@ func ConfigureBCCSP(optsPtr **factory.FactoryOpts, mspDir, homeDir string) error
 		log.Debugf("Initializing BCCSP with software options %+v", opts.SwOpts)
 	}
 	if opts.Pkcs11Opts != nil {
-		log.Debugf("Initializing BCCSP with PKCS11 options %+v", opts.Pkcs11Opts)
+		log.Debugf("Initializing BCCSP with PKCS11 options %+v", sanitizePKCS11Opts(*opts.Pkcs11Opts))
 	}
 	*optsPtr = opts
 	return nil
+}
+
+// redacts label and pin from PKCS11 opts
+func sanitizePKCS11Opts(opts pkcs11.PKCS11Opts) pkcs11.PKCS11Opts {
+	mask := strings.Repeat("*", 6)
+	opts.Pin = mask
+	opts.Label = mask
+	return opts
 }

--- a/internal/pkg/util/configurebccsp_test.go
+++ b/internal/pkg/util/configurebccsp_test.go
@@ -1,0 +1,51 @@
+// +build pkcs11
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric/bccsp/factory"
+	"github.com/hyperledger/fabric/bccsp/pkcs11"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigureBCCSP(t *testing.T) {
+	mspDir := "msp"
+	lib, pin, label := pkcs11.FindPKCS11Lib()
+	opts := &factory.FactoryOpts{
+		ProviderName: "PKCS11",
+		Pkcs11Opts: &pkcs11.PKCS11Opts{
+			SecLevel:   256,
+			HashFamily: "SHA2",
+			Library:    lib,
+			Label:      label,
+			Pin:        pin,
+		},
+	}
+
+	err := ConfigureBCCSP(&opts, mspDir, "")
+	if err != nil {
+		t.Fatalf("Failed initialization 1 of BCCSP: %s", err)
+	}
+}
+
+func TestSanitizePKCS11Opts(t *testing.T) {
+	lib, pin, label := pkcs11.FindPKCS11Lib()
+	opts := pkcs11.PKCS11Opts{
+		SecLevel:   256,
+		HashFamily: "SHA2",
+		Library:    lib,
+		Label:      label,
+		Pin:        pin,
+	}
+	p11opts := sanitizePKCS11Opts(opts)
+	assert.Equal(t, p11opts.Label, "******")
+	assert.Equal(t, p11opts.Pin, "******")
+}


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Redacts label and pin from bccsp initialization logs

#### Related issues

[FABC-912](https://jira.hyperledger.org/browse/FABC-912)