### PR TITLE
Fix indentation in config.yaml

### DIFF
--- a/docs/source/deployguide/use_CA.md
+++ b/docs/source/deployguide/use_CA.md
@@ -97,19 +97,19 @@ Or you can manually copy the Node OU material into the `config.yaml` file for th
 
 ```
 NodeOUs:
-Enable: true
-ClientOUIdentifier:
-  Certificate: cacerts/<root CA cert for this org>.pem
-  OrganizationalUnitIdentifier: client
-PeerOUIdentifier:
-  Certificate: cacerts/<root CA cert for this org>.pem
-  OrganizationalUnitIdentifier: peer
-AdminOUIdentifier:
-  Certificate: cacerts/<root CA cert for this org>.pem
-  OrganizationalUnitIdentifier: admin
-OrdererOUIdentifier:
-  Certificate: cacerts/<root CA cert for this org>.pem
-  OrganizationalUnitIdentifier: orderer
+  Enable: true
+  ClientOUIdentifier:
+    Certificate: cacerts/<root CA cert for this org>.pem
+    OrganizationalUnitIdentifier: client
+  PeerOUIdentifier:
+    Certificate: cacerts/<root CA cert for this org>.pem
+    OrganizationalUnitIdentifier: peer
+  AdminOUIdentifier:
+    Certificate: cacerts/<root CA cert for this org>.pem
+    OrganizationalUnitIdentifier: admin
+  OrdererOUIdentifier:
+    Certificate: cacerts/<root CA cert for this org>.pem
+    OrganizationalUnitIdentifier: orderer
 ```
 
 In a production scenario, it is assumed that users will be creating only one organization. However, it is a good practice to establish a separate folder structure for this organization and then create a structure underneath this organization for your `msp` (defining the organization) and your nodes (which will have a local MSP and TLS sections).


### PR DESCRIPTION
Peer node would not start because the config.yaml file was missing an indentation under `NodeOUs:`
  

#### Type of change

- Documentation update

#### Description

I changed the indentation from:
```
NodeOUs:
Enable: true
```

to 
```
NodeOUs:
  Enable: true
```