### PR TITLE
Move StartNonceSweeper out of NonceManager constructor

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/hyperledger/fabric-ca/lib/metadata"
 	"github.com/hyperledger/fabric-ca/lib/server/db"
 	dbutil "github.com/hyperledger/fabric-ca/lib/server/db/util"
+	idemix "github.com/hyperledger/fabric-ca/lib/server/idemix"
 	servermetrics "github.com/hyperledger/fabric-ca/lib/server/metrics"
 	"github.com/hyperledger/fabric-ca/lib/server/operations"
 	stls "github.com/hyperledger/fabric-ca/lib/tls"
@@ -195,6 +196,10 @@ func (s *Server) Start() (err error) {
 		return nil
 	}
 
+	for _, ca := range s.caMap {
+		startNonceSweeper(ca)
+	}
+
 	// Start listening and serving
 	err = s.listenAndServe()
 	if err != nil {
@@ -206,6 +211,14 @@ func (s *Server) Start() (err error) {
 	}
 
 	return nil
+}
+
+func startNonceSweeper(ca *CA) {
+	if nm, ok := ca.issuer.(interface{ NonceManager() idemix.NonceManager }); ok && nm != nil {
+		if ss, ok := nm.NonceManager().(interface{ StartNonceSweeper() }); ok {
+			ss.StartNonceSweeper()
+		}
+	}
 }
 
 // Stop the server

--- a/lib/server/idemix/nonce.go
+++ b/lib/server/idemix/nonce.go
@@ -145,7 +145,6 @@ func (nm *nonceManager) startNonceSweeper() {
 func (nm *nonceManager) sweep(curTime time.Time) error {
 	err := nm.removeExpiredNoncesFromDB(curTime)
 	if err != nil {
-		log.Errorf("Failed to deleted expired nonces from DB for CA %s: %s", nm.issuer.Name(), err.Error())
 		return err
 	}
 	return nil

--- a/lib/server/idemix/nonce.go
+++ b/lib/server/idemix/nonce.go
@@ -84,7 +84,6 @@ func NewNonceManager(issuer MyIssuer, clock Clock, level int) (NonceManager, err
 		return nil, errors.Wrapf(err, fmt.Sprintf("Failed to parse idemix.noncesweepinterval config option while initializing Nonce manager for Issuer '%s'",
 			issuer.Name()))
 	}
-	mgr.startNonceSweeper()
 	return mgr, nil
 }
 
@@ -131,11 +130,13 @@ func (nm *nonceManager) SweepExpiredNonces() error {
 	return nm.sweep(nm.clock.Now().UTC())
 }
 
-func (nm *nonceManager) startNonceSweeper() {
-	ticker := time.NewTicker(nm.nonceSweepInterval)
+// StartNonceSweeper starts a separate thread that will remove expired
+// nonces at the interval speciifed by the idemix.noncesweepinterval. This
+// function should be called while initializing the server.
+func (nm *nonceManager) StartNonceSweeper() {
 	go func() {
+		ticker := time.NewTicker(nm.nonceSweepInterval)
 		for t := range ticker.C {
-			log.Debugf("Cleaning up expired nonces for CA '%s'", nm.issuer.Name())
 			nm.sweep(t.UTC())
 		}
 	}()
@@ -143,11 +144,8 @@ func (nm *nonceManager) startNonceSweeper() {
 
 // sweep deletes all nonces that have expired (whose expiry is less than current timestamp)
 func (nm *nonceManager) sweep(curTime time.Time) error {
-	err := nm.removeExpiredNoncesFromDB(curTime)
-	if err != nil {
-		return err
-	}
-	return nil
+	log.Debugf("Cleaning up expired nonces for CA '%s'", nm.issuer.Name())
+	return nm.removeExpiredNoncesFromDB(curTime)
 }
 
 // Gets the specified nonce from DB and removes it from the DB


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

First commit: 
- No need to log the same thing twice, especially when the second log has less context about the error. 

Second commit:
- Move StartNonceSweeper out of NonceManager constructor, since not all uses of the NonceManager require/expect a separate go thread to be spawned to sweep for expired nonces. Have the server call it instead.

#### Related issues

[FABC-911](https://jira.hyperledger.org/browse/FABC-911)