### PR TITLE
[FABC-920] Modify cdr command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following are guidelines to follow when contributing:
 2. To run the unit tests manually:
 
    ```
-   # cdr
+   # cd $GOPATH/src/github.com/hyperledger/fabric-ca
    # make unit-tests
    ```
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

* Change `cdr` to `cd $GOPATH/src/github.com/hyperledger/fabric-ca` in README.md

Signed-off-by: Sol Kang <pdpxpd@gmail.com>