### PR TITLE
Allow reenroll to reuse existing private key

### DIFF
--- a/cmd/fabric-ca-client/command/config.go
+++ b/cmd/fabric-ca-client/command/config.go
@@ -106,6 +106,11 @@ tls:
 #
 #  cn - Used by CAs to determine which domain the certificate is to be generated for
 #
+#  keyrequest - Properties to use when generating a private key.
+#     algo - key generation algorithm to use
+#     size - size of key to generate
+#     reusekey - reuse existing key during reenrollment
+#
 #  serialnumber - The serialnumber field, if specified, becomes part of the issued
 #     certificate's DN (Distinguished Name).  For example, one use case for this is
 #     a company with its own CA (Certificate Authority) which issues certificates
@@ -139,6 +144,7 @@ csr:
   keyrequest:
     algo: ecdsa
     size: 256
+    reusekey: false
   serialnumber:
   names:
     - C: US

--- a/docs/source/clientcli.rst
+++ b/docs/source/clientcli.rst
@@ -28,6 +28,7 @@ Fabric-CA Client's CLI
           --csr.cn string                The common name field of the certificate signing request
           --csr.hosts strings            A list of comma-separated host names in a certificate signing request
           --csr.keyrequest.algo string   Specify key algorithm
+          --csr.keyrequest.reusekey      Reuse existing key during reenrollment
           --csr.keyrequest.size int      Specify key size
           --csr.names strings            A list of comma-separated CSR names of the form <name>=<value> (e.g. C=CA,O=Org1)
           --csr.serialnumber string      The serial number in a certificate signing request

--- a/docs/source/clientconfig.rst
+++ b/docs/source/clientconfig.rst
@@ -75,6 +75,11 @@ Fabric-CA Client's Configuration File
     #
     #  cn - Used by CAs to determine which domain the certificate is to be generated for
     #
+    #  keyrequest - Properties to use when generating a private key.
+    #     algo - key generation algorithm to use
+    #     size - size of key to generate
+    #     reusekey - reuse existing key during reenrollment
+    #
     #  serialnumber - The serialnumber field, if specified, becomes part of the issued
     #     certificate's DN (Distinguished Name).  For example, one use case for this is
     #     a company with its own CA (Certificate Authority) which issues certificates
@@ -108,6 +113,7 @@ Fabric-CA Client's Configuration File
       keyrequest:
         algo: ecdsa
         size: 256
+        reusekey: false
       serialnumber:
       names:
         - C: US

--- a/docs/source/servercli.rst
+++ b/docs/source/servercli.rst
@@ -34,6 +34,7 @@ Fabric-CA Server's CLI
           --csr.cn string                             The common name field of the certificate signing request to a parent fabric-ca-server
           --csr.hosts strings                         A list of comma-separated host names in a certificate signing request to a parent fabric-ca-server
           --csr.keyrequest.algo string                Specify key algorithm
+          --csr.keyrequest.reusekey                   Reuse existing key during reenrollment
           --csr.keyrequest.size int                   Specify key size
           --csr.serialnumber string                   The serial number in a certificate signing request to a parent fabric-ca-server
           --db.datasource string                      Data source which is database specific (default "fabric-ca-server.db")

--- a/internal/pkg/api/client.go
+++ b/internal/pkg/api/client.go
@@ -306,10 +306,13 @@ type TimeRange struct {
 	EndTime   string
 }
 
-// KeyRequest encapsulates size and algorithm for the key to be generated
+// KeyRequest encapsulates size and algorithm for the key to be generated.
+// If ReuseKey is set, reenrollment requests will reuse the existing private
+// key.
 type KeyRequest struct {
-	Algo string `json:"algo" yaml:"algo" help:"Specify key algorithm"`
-	Size int    `json:"size" yaml:"size" help:"Specify key size"`
+	Algo     string `json:"algo" yaml:"algo" help:"Specify key algorithm"`
+	Size     int    `json:"size" yaml:"size" help:"Specify key size"`
+	ReuseKey bool   `json:"reusekey" yaml:"reusekey" help:"Reuse existing key during reenrollment"`
 }
 
 // Attribute is a name and value pair

--- a/lib/client.go
+++ b/lib/client.go
@@ -8,6 +8,8 @@ package lib
 
 import (
 	"bytes"
+	"crypto"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -33,6 +35,7 @@ import (
 	"github.com/hyperledger/fabric-ca/lib/streamer"
 	"github.com/hyperledger/fabric-ca/lib/tls"
 	"github.com/hyperledger/fabric/bccsp"
+	cspsigner "github.com/hyperledger/fabric/bccsp/signer"
 	"github.com/hyperledger/fabric/idemix"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -199,16 +202,10 @@ func (c *Client) GenCSR(req *api.CSRInfo, id string) ([]byte, bccsp.Key, error) 
 		return nil, nil, err
 	}
 
-	cr := c.newCertificateRequest(req)
-	cr.CN = id
+	cr := c.newCertificateRequest(req, id)
 
-	if (cr.KeyRequest == nil) || (cr.KeyRequest.Size() == 0 && cr.KeyRequest.Algo() == "") {
-		cr.KeyRequest = newCfsslKeyRequest(api.NewKeyRequest())
-	}
-
-	key, cspSigner, err := util.BCCSPKeyRequestGenerate(cr, c.csp)
+	cspSigner, key, err := c.generateCSPSigner(cr, nil)
 	if err != nil {
-		log.Debugf("failed generating BCCSP key: %s", err)
 		return nil, nil, err
 	}
 
@@ -219,6 +216,55 @@ func (c *Client) GenCSR(req *api.CSRInfo, id string) ([]byte, bccsp.Key, error) 
 	}
 
 	return csrPEM, key, nil
+}
+
+// GenCSRUsingKey generates a CSR (Certificate Signing Request) using the
+// supplied private key.
+func (c *Client) GenCSRUsingKey(req *api.CSRInfo, id string, k bccsp.Key) ([]byte, bccsp.Key, error) {
+	log.Debugf("GenCSRUsingKey %+v", req)
+
+	err := c.Init()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cr := c.newCertificateRequest(req, id)
+
+	cspSigner, key, err := c.generateCSPSigner(cr, k)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	csrPEM, err := csr.Generate(cspSigner, cr)
+	if err != nil {
+		log.Debugf("failed generating CSR: %s", err)
+		return nil, nil, err
+	}
+
+	return csrPEM, key, nil
+}
+
+// generateCSPSigner generates a crypto.Signer for a given certificate request.
+// If a key is not provided, a new one will be generated.
+func (c *Client) generateCSPSigner(cr *csr.CertificateRequest, key bccsp.Key) (crypto.Signer, bccsp.Key, error) {
+	if key == nil {
+		// generate new key
+		key, cspSigner, err := util.BCCSPKeyRequestGenerate(cr, c.csp)
+		if err != nil {
+			log.Debugf("failed generating BCCSP key: %s", err)
+			return nil, nil, err
+		}
+		return cspSigner, key, nil
+	}
+
+	// use existing key
+	log.Debugf("generating signer with existing key: %s", hex.EncodeToString(key.SKI()))
+	cspSigner, err := cspsigner.New(c.csp, key)
+	if err != nil {
+		return nil, nil, errors.WithMessage(err, "Failed initializing CryptoSigner")
+	}
+
+	return cspSigner, key, nil
 }
 
 // Enroll enrolls a new identity
@@ -493,29 +539,33 @@ func (c *Client) newIdemixEnrollmentResponse(identity *Identity, result *api.Ide
 
 // newCertificateRequest creates a certificate request which is used to generate
 // a CSR (Certificate Signing Request)
-func (c *Client) newCertificateRequest(req *api.CSRInfo) *csr.CertificateRequest {
-	cr := csr.CertificateRequest{}
-	if req != nil && req.Names != nil {
-		cr.Names = req.Names
-	}
-	if req != nil && req.Hosts != nil {
-		cr.Hosts = req.Hosts
-	} else {
-		// Default requested hosts are local hostname
-		hostname, _ := os.Hostname()
-		if hostname != "" {
-			cr.Hosts = make([]string, 1)
-			cr.Hosts[0] = hostname
-		}
-	}
-	if req != nil && req.KeyRequest != nil {
-		cr.KeyRequest = newCfsslKeyRequest(req.KeyRequest)
-	}
+func (c *Client) newCertificateRequest(req *api.CSRInfo, id string) *csr.CertificateRequest {
+	cr := &csr.CertificateRequest{CN: id}
+
 	if req != nil {
+		cr.Names = req.Names
+		cr.Hosts = req.Hosts
 		cr.CA = req.CA
 		cr.SerialNumber = req.SerialNumber
+
+		keyRequest := req.KeyRequest
+		if keyRequest == nil || (keyRequest.Size == 0 && keyRequest.Algo == "") {
+			keyRequest = api.NewKeyRequest()
+		}
+		cr.KeyRequest = newCfsslKeyRequest(keyRequest)
+
+		return cr
 	}
-	return &cr
+
+	// Default requested hosts are local hostname
+	hostname, _ := os.Hostname()
+	if hostname != "" {
+		cr.Hosts = []string{hostname}
+	}
+
+	cr.KeyRequest = newCfsslKeyRequest(api.NewKeyRequest())
+
+	return cr
 }
 
 // newIdemixCredentialRequest returns CredentialRequest object, a secret key, and a random number used in

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/hyperledger/fabric-ca/internal/pkg/util"
 	. "github.com/hyperledger/fabric-ca/lib"
 	"github.com/hyperledger/fabric-ca/lib/attrmgr"
+	"github.com/hyperledger/fabric-ca/lib/client/credential/x509"
 	"github.com/hyperledger/fabric-ca/lib/tls"
+	"github.com/hyperledger/fabric/bccsp"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -716,18 +719,76 @@ func testEnrollMiscFailures(c *Client, t *testing.T) {
 	}
 }
 
+func getKeyFromIdentity(i *Identity) (bccsp.Key, error) {
+	val, err := i.GetX509Credential().Val()
+	if err != nil {
+		return nil, errors.Errorf("getKeyFromIdentity: failed getting x509 credentials: %s", err)
+	}
+	return val.(*x509.Signer).Key(), nil
+}
+
 func testReenroll(c *Client, t *testing.T) {
 	id, err := c.LoadMyIdentity()
 	if err != nil {
 		t.Errorf("testReenroll: failed LoadMyIdentity: %s", err)
 		return
 	}
-	eresp, err := id.Reenroll(&api.ReenrollmentRequest{})
+
+	//  generate new key during reenroll
+	originalKey, err := getKeyFromIdentity(id)
+	if err != nil {
+		t.Errorf("testReenroll: %s", err)
+		return
+	}
+	eresp, err := id.Reenroll(&api.ReenrollmentRequest{
+		CSR: &api.CSRInfo{
+			KeyRequest: &api.KeyRequest{
+				ReuseKey: false,
+			},
+		},
+	})
 	if err != nil {
 		t.Errorf("testReenroll: failed reenroll: %s", err)
 		return
 	}
 	id = eresp.Identity
+	newKey, err := getKeyFromIdentity(id)
+	if err != nil {
+		t.Errorf("testReenroll: %s", err)
+		return
+	}
+	if originalKey == newKey {
+		t.Error("testReenroll: reenroll should have generated new key")
+		return
+	}
+	err = id.Store()
+	if err != nil {
+		t.Errorf("testReenroll: failed Store: %s", err)
+	}
+
+	// reuse existing key during reenroll
+	originalKey = newKey
+	eresp, err = id.Reenroll(&api.ReenrollmentRequest{
+		CSR: &api.CSRInfo{
+			KeyRequest: &api.KeyRequest{
+				ReuseKey: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Errorf("testReenroll: failed reenroll: %s", err)
+		return
+	}
+	id = eresp.Identity
+	newKey, err = getKeyFromIdentity(id)
+	if err != nil {
+		t.Errorf("testReenroll: %s", err)
+		return
+	}
+	if originalKey != newKey {
+		t.Error("testReenroll: reenroll should have reused existing key")
+		return
+	}
 	err = id.Store()
 	if err != nil {
 		t.Errorf("testReenroll: failed Store: %s", err)

--- a/lib/client_whitebox_test.go
+++ b/lib/client_whitebox_test.go
@@ -554,7 +554,7 @@ func TestCWBNewCertificateRequest(t *testing.T) {
 		Hosts:      []string{},
 		KeyRequest: api.NewKeyRequest(),
 	}
-	if c.newCertificateRequest(req) == nil {
+	if c.newCertificateRequest(req, "fake-id") == nil {
 		t.Error("newCertificateRequest failed")
 	}
 }

--- a/lib/identity.go
+++ b/lib/identity.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hyperledger/fabric-ca/lib/client/credential"
 	"github.com/hyperledger/fabric-ca/lib/client/credential/idemix"
 	"github.com/hyperledger/fabric-ca/lib/client/credential/x509"
+	"github.com/hyperledger/fabric/bccsp"
 	"github.com/pkg/errors"
 )
 
@@ -130,9 +131,30 @@ func (i *Identity) RegisterAndEnroll(req *api.RegistrationRequest) (*Identity, e
 func (i *Identity) Reenroll(req *api.ReenrollmentRequest) (*EnrollmentResponse, error) {
 	log.Debugf("Reenrolling %s", util.StructToString(req))
 
-	csrPEM, key, err := i.client.GenCSR(req.CSR, i.GetName())
-	if err != nil {
-		return nil, err
+	var (
+		key    bccsp.Key
+		csrPEM []byte
+		err    error
+	)
+	if req.CSR != nil && req.CSR.KeyRequest != nil {
+		if req.CSR.KeyRequest.ReuseKey {
+			val, err := i.GetX509Credential().Val()
+			if err != nil {
+				return nil, err
+			}
+			key = val.(*x509.Signer).Key()
+			csrPEM, key, err = i.client.GenCSRUsingKey(req.CSR, i.GetName(), key)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if csrPEM == nil {
+		csrPEM, key, err = i.client.GenCSR(req.CSR, i.GetName())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	reqNet := &api.ReenrollmentRequestNet{


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Allow reenroll to reuse existing private key instead of always generating a new one.


#### Related issues

[FABC-914](https://jira.hyperledger.org/browse/FABC-914)