### PR TITLE
Allow reenroll to reuse existing private key (release-1.4)

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -345,9 +345,12 @@ type TimeRange struct {
 }
 
 // BasicKeyRequest encapsulates size and algorithm for the key to be generated
+// If ReuseKey is set, reenrollment requests will reuse the existing private
+// key.
 type BasicKeyRequest struct {
-	Algo string `json:"algo" yaml:"algo" help:"Specify key algorithm"`
-	Size int    `json:"size" yaml:"size" help:"Specify key size"`
+	Algo     string `json:"algo" yaml:"algo" help:"Specify key algorithm"`
+	Size     int    `json:"size" yaml:"size" help:"Specify key size"`
+	ReuseKey bool   `json:"reusekey" yaml:"reusekey" help:"Reuse existing key during reenrollment"`
 }
 
 // Attribute is a name and value pair

--- a/cmd/fabric-ca-client/command/config.go
+++ b/cmd/fabric-ca-client/command/config.go
@@ -106,6 +106,11 @@ tls:
 #
 #  cn - Used by CAs to determine which domain the certificate is to be generated for
 #
+#  keyrequest - Properties to use when generating a private key.
+#     algo - key generation algorithm to use
+#     size - size of key to generate
+#     reusekey - reuse existing key during reenrollment
+#
 #  serialnumber - The serialnumber field, if specified, becomes part of the issued
 #     certificate's DN (Distinguished Name).  For example, one use case for this is
 #     a company with its own CA (Certificate Authority) which issues certificates
@@ -139,6 +144,7 @@ csr:
   keyrequest:
     algo: ecdsa
     size: 256
+    reusekey: false
   serialnumber:
   names:
     - C: US

--- a/docs/source/clientcli.rst
+++ b/docs/source/clientcli.rst
@@ -27,6 +27,7 @@ Fabric-CA Client's CLI
           --csr.cn string                  The common name field of the certificate signing request
           --csr.hosts stringSlice          A list of comma-separated host names in a certificate signing request
           --csr.keyrequest.algo string     Specify key algorithm
+          --csr.keyrequest.reusekey        Reuse existing key during reenrollment
           --csr.keyrequest.size int        Specify key size
           --csr.names stringSlice          A list of comma-separated CSR names of the form <name>=<value> (e.g. C=CA,O=Org1)
           --csr.serialnumber string        The serial number in a certificate signing request

--- a/docs/source/clientconfig.rst
+++ b/docs/source/clientconfig.rst
@@ -75,6 +75,11 @@ Fabric-CA Client's Configuration File
     #
     #  cn - Used by CAs to determine which domain the certificate is to be generated for
     #
+    #  keyrequest - Properties to use when generating a private key.
+    #     algo - key generation algorithm to use
+    #     size - size of key to generate
+    #     reusekey - reuse existing key during reenrollment
+    #
     #  serialnumber - The serialnumber field, if specified, becomes part of the issued
     #     certificate's DN (Distinguished Name).  For example, one use case for this is
     #     a company with its own CA (Certificate Authority) which issues certificates
@@ -108,6 +113,7 @@ Fabric-CA Client's Configuration File
       keyrequest:
         algo: ecdsa
         size: 256
+        reusekey: false
       serialnumber:
       names:
         - C: US

--- a/docs/source/servercli.rst
+++ b/docs/source/servercli.rst
@@ -33,6 +33,7 @@ Fabric-CA Server's CLI
           --csr.cn string                             The common name field of the certificate signing request to a parent fabric-ca-server
           --csr.hosts stringSlice                     A list of comma-separated host names in a certificate signing request to a parent fabric-ca-server
           --csr.keyrequest.algo string                Specify key algorithm
+          --csr.keyrequest.reusekey                   Reuse existing key during reenrollment
           --csr.keyrequest.size int                   Specify key size
           --csr.serialnumber string                   The serial number in a certificate signing request to a parent fabric-ca-server
           --db.datasource string                      Data source which is database specific (default "fabric-ca-server.db")

--- a/lib/client_whitebox_test.go
+++ b/lib/client_whitebox_test.go
@@ -555,7 +555,7 @@ func TestCWBNewCertificateRequest(t *testing.T) {
 		Hosts:      []string{},
 		KeyRequest: api.NewBasicKeyRequest(),
 	}
-	if c.newCertificateRequest(req) == nil {
+	if c.newCertificateRequest(req, "fake-id") == nil {
 		t.Error("newCertificateRequest failed")
 	}
 }


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Allow reenroll to reuse existing private key instead of always generating a new one.


#### Related issues

[FABC-914](https://jira.hyperledger.org/browse/FABC-914)