### PR TITLE
Update v1.4.9 release note to clarify reenroll improvement

### DIFF
--- a/release_notes/v1.4.9.md
+++ b/release_notes/v1.4.9.md
@@ -8,8 +8,9 @@ Fixes
 
 fabric-ca-client `reenroll` command always generated a new private key in the certificate signing request.
 This fix allows reenroll command to use the existing private key by setting the
-`--csr.keyrequest.reusekey` flag. This may be important if the previously issued certificate expires
-and needs to be re-issued, without updating the public key within the certificate.
+`--csr.keyrequest.reusekey` flag. This may be important if the previously issued certificate is going to
+expire soon and needs to be re-issued, without updating the public key within the certificate.
+Note that reenroll will fail if the previously issued certificate has already expired.
 
 
 Dependencies


### PR DESCRIPTION
Update v1.4.9 release note to clarify reenroll improvement

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
