### PR TITLE
Fix a typo in users-guide

### DIFF
--- a/docs/source/users-guide.rst
+++ b/docs/source/users-guide.rst
@@ -1647,7 +1647,7 @@ The following are the supported reasons that can be specified using ``-r`` flag:
   1. unspecified
   2. keycompromise
   3. cacompromise
-  4. affiliationchange
+  4. affiliationchanged
   5. superseded
   6. cessationofoperation
   7. certificatehold


### PR DESCRIPTION
#### Type of change
- Documentation update

#### Description
affiliationchange should be affiliationchanged.