### PR TITLE
[FABC-909] Check If DB Exists Prior to Creating

### DIFF
--- a/lib/server/db/mysql/mysql_test.go
+++ b/lib/server/db/mysql/mysql_test.go
@@ -4,13 +4,14 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package mysql
+package mysql_test
 
 import (
 	"context"
 	"errors"
 	"path/filepath"
 
+	"github.com/hyperledger/fabric-ca/lib/server/db/mysql"
 	"github.com/hyperledger/fabric-ca/lib/server/db/mysql/mocks"
 	"github.com/hyperledger/fabric-ca/lib/tls"
 	. "github.com/onsi/ginkgo"
@@ -23,7 +24,7 @@ const (
 
 var _ = Describe("Mysql", func() {
 	var (
-		db     *Mysql
+		db     *mysql.Mysql
 		mockDB *mocks.FabricCADB
 	)
 
@@ -32,7 +33,7 @@ var _ = Describe("Mysql", func() {
 			Enabled:   true,
 			CertFiles: []string{filepath.Join(testdataDir, "root.pem")},
 		}
-		db = NewDB(
+		db = mysql.NewDB(
 			"root:rootpw@tcp(localhost:3306)/fabric_ca_db",
 			"",
 			tls,
@@ -103,12 +104,10 @@ var _ = Describe("Mysql", func() {
 
 		When("the database already exists", func() {
 			It("does not attempt to create the database", func() {
-				mockDB.GetCalls(func(s string, i interface{}, s2 string, i2 ...interface{}) error {
-					exists := i.(*bool)
-					*exists = true
-					i = exists
+				mockDB.GetStub = func(s string, i interface{}, s2 string, i2 ...interface{}) error {
+					*(i.(*bool)) = true
 					return nil
-				})
+				}
 				db.SqlxDB = mockDB
 				sqlxDB, err := db.CreateDatabase()
 				Expect(err).NotTo(HaveOccurred())

--- a/lib/server/db/postgres/postgres_test.go
+++ b/lib/server/db/postgres/postgres_test.go
@@ -4,13 +4,12 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package postgres_test
+package postgres
 
 import (
 	"context"
 	"path/filepath"
 
-	"github.com/hyperledger/fabric-ca/lib/server/db/postgres"
 	"github.com/hyperledger/fabric-ca/lib/server/db/postgres/mocks"
 	"github.com/hyperledger/fabric-ca/lib/tls"
 	. "github.com/onsi/ginkgo"
@@ -24,7 +23,7 @@ const (
 
 var _ = Describe("Postgres", func() {
 	var (
-		db     *postgres.Postgres
+		db     *Postgres
 		mockDB *mocks.FabricCADB
 	)
 
@@ -33,7 +32,7 @@ var _ = Describe("Postgres", func() {
 			Enabled:   true,
 			CertFiles: []string{filepath.Join(testdataDir, "root.pem")},
 		}
-		db = postgres.NewDB(
+		db = NewDB(
 			"host=localhost port=5432 user=root password=rootpw dbname=fabric_ca",
 			"",
 			tls,
@@ -44,7 +43,7 @@ var _ = Describe("Postgres", func() {
 
 	Context("open connection to database", func() {
 		It("fails to connect if the contains incorrect syntax", func() {
-			db = postgres.NewDB(
+			db = NewDB(
 				"hos) (t=localhost port=5432 user=root password=rootpw dbname=fabric-ca",
 				"",
 				nil,
@@ -54,7 +53,7 @@ var _ = Describe("Postgres", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).Should(Equal("Database name 'fabric-ca' cannot contain any '-' or end with '.db'"))
 
-			db = postgres.NewDB(
+			db = NewDB(
 				"host=localhost port=5432 user=root password=rootpw dbname=fabric_ca.db",
 				"",
 				nil,
@@ -127,19 +126,40 @@ var _ = Describe("Postgres", func() {
 	})
 
 	Context("creating fabric ca database", func() {
-		It("returns an error if unable execute create fabric ca database sql", func() {
-			mockDB.ExecReturns(nil, errors.New("error creating database"))
-			db.SqlxDB = mockDB
-			_, err := db.CreateDatabase()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("Failed to create Postgres database: Failed to execute create database query: error creating database"))
+		When("creating the Fabric CA database fails", func() {
+			It("returns an error", func() {
+				mockDB.ExecReturns(nil, errors.New("error creating database"))
+				db.SqlxDB = mockDB
+				_, err := db.CreateDatabase()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Failed to create Postgres database: Failed to execute create database query: error creating database"))
+			})
 		})
 
-		It("creates the fabric ca database", func() {
-			db.SqlxDB = mockDB
+		When("the database does not exist", func() {
+			It("creates the fabric ca database", func() {
+				db.SqlxDB = mockDB
+				sqlxDB, err := db.CreateDatabase()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(db.SqlxDB).To(Equal(sqlxDB))
+				Expect(mockDB.ExecCallCount()).To(Equal(1))
+			})
+		})
 
-			_, err := db.CreateDatabase()
-			Expect(err).NotTo(HaveOccurred())
+		When("the database already exists", func() {
+			It("does not attempt to create the database", func() {
+				mockDB.GetCalls(func(s string, i interface{}, s2 string, i2 ...interface{}) error {
+					exists := i.(*bool)
+					*exists = true
+					i = exists
+					return nil
+				})
+				db.SqlxDB = mockDB
+				sqlxDB, err := db.CreateDatabase()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(db.SqlxDB).To(Equal(sqlxDB))
+				Expect(mockDB.ExecCallCount()).To(Equal(0))
+			})
 		})
 	})
 


### PR DESCRIPTION
Prior to creating the CA database, first determine if it exists in MySQL and Postgres databases. This is helpful when the DB user does not have permission to create the DB and the DB was created by an Admin out of band.

Signed-off-by: Brett Logan <brett.t.logan@ibm.com>
