### PR TITLE
[FABC-905] Add passfile to server config file template

### DIFF
--- a/cmd/fabric-ca-server/servercmd.go
+++ b/cmd/fabric-ca-server/servercmd.go
@@ -154,6 +154,8 @@ func (s *ServerCmd) registerFlags() {
 	pflags.StringVarP(&s.homeDirectory, "home", "H", "", fmt.Sprintf("Server's home directory (default \"%s\")", filepath.Dir(cfg)))
 	util.FlagString(s.myViper, pflags, "boot", "b", "",
 		"The user:pass for bootstrap admin which is required to build default config file")
+	util.FlagString(s.myViper, pflags, "bootfile", "f", "",
+		"Password file for bootstrap admin which is required to build the default config file")
 
 	// Register flags for all tagged and exported fields in the config
 	s.cfg = &lib.ServerConfig{}

--- a/docs/source/servercli.rst
+++ b/docs/source/servercli.rst
@@ -18,6 +18,7 @@ Fabric-CA Server's CLI
     Flags:
           --address string                            Listening address of fabric-ca-server (default "0.0.0.0")
       -b, --boot string                               The user:pass for bootstrap admin which is required to build default config file
+      -f, --bootfile string                           Password file for bootstrap admin which is required to build the default config file
           --ca.certfile string                        PEM-encoded CA certificate file (default "ca-cert.pem")
           --ca.chainfile string                       PEM-encoded CA chain file (default "ca-chain.pem")
           --ca.keyfile string                         PEM-encoded CA key file

--- a/docs/source/serverconfig.rst
+++ b/docs/source/serverconfig.rst
@@ -133,6 +133,7 @@ Fabric-CA Server's Configuration File
       identities:
          - name: <<<adminUserName>>>
            pass: <<<adminPassword>>>
+           passFile: 
            type: client
            affiliation: ""
            attrs:

--- a/lib/ca.go
+++ b/lib/ca.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -823,6 +824,17 @@ func (ca *CA) addIdentity(id *CAConfigIdentity, errIfFound bool) error {
 
 	if err != nil {
 		return err
+	}
+
+	// A password file takes precedence over password
+	if id.PassFile != "" {
+		passBytes, err := util.ReadFile(id.PassFile)
+		if err != nil {
+			return errors.WithMessage(err, fmt.Sprintf("Failed to read password from '%s'", id.PassFile))
+		}
+		// Remove the newline from reading file
+		id.Pass = string(passBytes[:])
+		id.Pass = strings.TrimSuffix(id.Pass, "\n")
 	}
 
 	rec := cadbuser.Info{

--- a/lib/caconfig.go
+++ b/lib/caconfig.go
@@ -148,6 +148,7 @@ type CAConfigRegistry struct {
 type CAConfigIdentity struct {
 	Name           string `mask:"username"`
 	Pass           string `mask:"password"`
+	PassFile       string
 	Type           string
 	Affiliation    string
 	MaxEnrollments int


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

Add server config option passfile. This config will take precedence over password and will not be stored in the generated yaml. 

#### Related issues
[FABC-905](https://jira.hyperledger.org/browse/FABC-905)


