### PR TITLE
Ensure keystore stays under clientHome in test

### DIFF
--- a/lib/client/credential/x509/credential_test.go
+++ b/lib/client/credential/x509/credential_test.go
@@ -180,12 +180,9 @@ func TestRevokeSelf(t *testing.T) {
 		SwOpts: &factory.SwOpts{
 			HashFamily: "SHA2",
 			SecLevel:   256,
-			FileKeystore: &factory.FileKeystoreOpts{
-				KeyStorePath: "msp/keystore",
-			},
 		},
 	}
-	bccsp, err := util.InitBCCSP(&opts, filepath.Join(clientHome, "msp/keystore"), clientHome)
+	bccsp, err := util.InitBCCSP(&opts, "msp", clientHome)
 	if err != nil {
 		t.Fatalf("Failed initialize BCCSP: %s", err.Error())
 	}


### PR DESCRIPTION
Without this change, the directory is created relative to `$HOME` instead of the temporary `clientHome` set in the test.

In my case, the test failed to create the keystore at
```
  /home/testdata/revokeselftest251817125/msp/keystore/keystore
```
Where $HOME is `/home/username` and `/home` cannot be written to by regular users.