### PR TITLE
Delete undefined variable in lib/server_test.go

### DIFF
--- a/lib/server_test.go
+++ b/lib/server_test.go
@@ -2684,10 +2684,6 @@ func cleanTestSlateSRV(t *testing.T) {
 	if err != nil {
 		t.Errorf("RemoveAll failed: %s", err)
 	}
-	err = os.RemoveAll(serversDir)
-	if err != nil {
-		t.Errorf("RemoveAll failed: %s", err)
-	}
 	err = os.RemoveAll("../testdata/msp")
 	if err != nil {
 		t.Errorf("RemoveAll failed: %s", err)


### PR DESCRIPTION
#### Type of change
- Bug fix

#### Description
When execute go test server_test.go in local, it will be failed due to undefined "serversDir" variable.
I supposed "serversDir" variable is no longer use in server_test.go.