### PR TITLE
Update Go module dependencies for fabric v1.4.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b
-	github.com/hyperledger/fabric v1.4.9
+	github.com/hyperledger/fabric v1.4.11
 	github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a
 	github.com/hyperledger/fabric-lib-go v1.0.0
 	github.com/jmoiron/sqlx v1.2.0
@@ -34,7 +34,7 @@ require (
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/procfs v0.2.0 // indirect
-	github.com/spf13/cast v1.3.1
+	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b/go.mod h1:zT/uzhd
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/fabric v1.4.9 h1:Ght1O51URuaKBmFDNkKB+qdUF2Vb8CdcrVel+4hWy+w=
-github.com/hyperledger/fabric v1.4.9/go.mod h1:tGFAOCT696D3rG0Vofd2dyWYLySHlh0aQjf7Q1HAju0=
+github.com/hyperledger/fabric v1.4.11 h1:Z+cB0cPclR2VcoESlrcIRHI+vWv8TvRDESC9pwYw1nU=
+github.com/hyperledger/fabric v1.4.11/go.mod h1:tGFAOCT696D3rG0Vofd2dyWYLySHlh0aQjf7Q1HAju0=
 github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a h1:JAKZdGuUIjVmES0X31YUD7UqMR2rz/kxLluJuGvsXPk=
 github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
 github.com/hyperledger/fabric-lib-go v1.0.0 h1:UL1w7c9LvHZUSkIvHTDGklxFv2kTeva1QI2emOVc324=

--- a/internal/pkg/util/csp_test.go
+++ b/internal/pkg/util/csp_test.go
@@ -43,7 +43,6 @@ func testMain(m *testing.M) int {
 
 	opts := factory.GetDefaultOpts()
 	opts.SwOpts.FileKeystore = &factory.FileKeystoreOpts{KeyStorePath: tmpDir}
-	opts.SwOpts.Ephemeral = false
 	csp, err = factory.GetBCCSPFromOpts(opts)
 	if err != nil {
 		fmt.Printf("Could not initialize BCCSP Factories [%s]", err)

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -16,6 +16,7 @@ function filterExcludedAndGeneratedFiles() {
         '\.key$'
         '(^|/)LICENSE$'
         '\.md$'
+        '\.mod$'
         '\.pb\.go$'
         '\.pem$'
         '\.png$'

--- a/vendor/github.com/hyperledger/fabric/bccsp/factory/opts.go
+++ b/vendor/github.com/hyperledger/fabric/bccsp/factory/opts.go
@@ -23,8 +23,6 @@ func GetDefaultOpts() *FactoryOpts {
 		SwOpts: &SwOpts{
 			HashFamily: "SHA2",
 			SecLevel:   256,
-
-			Ephemeral: true,
 		},
 	}
 }

--- a/vendor/github.com/hyperledger/fabric/bccsp/factory/pkcs11factory.go
+++ b/vendor/github.com/hyperledger/fabric/bccsp/factory/pkcs11factory.go
@@ -47,18 +47,6 @@ func (f *PKCS11Factory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 	p11Opts := config.Pkcs11Opts
 
 	//TODO: PKCS11 does not need a keystore, but we have not migrated all of PKCS11 BCCSP to PKCS11 yet
-	var ks bccsp.KeyStore
-	if p11Opts.Ephemeral == true {
-		ks = sw.NewDummyKeyStore()
-	} else if p11Opts.FileKeystore != nil {
-		fks, err := sw.NewFileBasedKeyStore(nil, p11Opts.FileKeystore.KeyStorePath, false)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Failed to initialize software key store")
-		}
-		ks = fks
-	} else {
-		// Default to DummyKeystore
-		ks = sw.NewDummyKeyStore()
-	}
+	ks := sw.NewDummyKeyStore()
 	return pkcs11.New(*p11Opts, ks)
 }

--- a/vendor/github.com/hyperledger/fabric/bccsp/factory/swfactory.go
+++ b/vendor/github.com/hyperledger/fabric/bccsp/factory/swfactory.go
@@ -44,9 +44,7 @@ func (f *SWFactory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 	swOpts := config.SwOpts
 
 	var ks bccsp.KeyStore
-	if swOpts.Ephemeral == true {
-		ks = sw.NewDummyKeyStore()
-	} else if swOpts.FileKeystore != nil {
+	if swOpts.FileKeystore != nil {
 		fks, err := sw.NewFileBasedKeyStore(nil, swOpts.FileKeystore.KeyStorePath, false)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Failed to initialize software key store")
@@ -65,11 +63,8 @@ func (f *SWFactory) Get(config *FactoryOpts) (bccsp.BCCSP, error) {
 // SwOpts contains options for the SWFactory
 type SwOpts struct {
 	// Default algorithms when not specified (Deprecated?)
-	SecLevel   int    `mapstructure:"security" json:"security" yaml:"Security"`
-	HashFamily string `mapstructure:"hash" json:"hash" yaml:"Hash"`
-
-	// Keystore Options
-	Ephemeral     bool               `mapstructure:"tempkeys,omitempty" json:"tempkeys,omitempty"`
+	SecLevel      int                `mapstructure:"security" json:"security" yaml:"Security"`
+	HashFamily    string             `mapstructure:"hash" json:"hash" yaml:"Hash"`
 	FileKeystore  *FileKeystoreOpts  `mapstructure:"filekeystore,omitempty" json:"filekeystore,omitempty" yaml:"FileKeyStore"`
 	DummyKeystore *DummyKeystoreOpts `mapstructure:"dummykeystore,omitempty" json:"dummykeystore,omitempty"`
 	InmemKeystore *InmemKeystoreOpts `mapstructure:"inmemkeystore,omitempty" json:"inmemkeystore,omitempty"`

--- a/vendor/github.com/hyperledger/fabric/bccsp/pkcs11/pkcs11.go
+++ b/vendor/github.com/hyperledger/fabric/bccsp/pkcs11/pkcs11.go
@@ -490,15 +490,14 @@ func (csp *impl) findKeyPairFromSKI(session pkcs11.SessionHandle, ski []byte, ke
 	if err := csp.ctx.FindObjectsInit(session, template); err != nil {
 		return 0, err
 	}
+	defer csp.ctx.FindObjectsFinal(session)
 
 	// single session instance, assume one hit only
 	objs, _, err := csp.ctx.FindObjects(session, 1)
 	if err != nil {
 		return 0, err
 	}
-	if err = csp.ctx.FindObjectsFinal(session); err != nil {
-		return 0, err
-	}
+
 	if len(objs) == 0 {
 		return 0, fmt.Errorf("Key not found [%s]", hex.Dump(keyId))
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -95,7 +95,7 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/hyperledger/fabric v1.4.9
+# github.com/hyperledger/fabric v1.4.11
 ## explicit
 github.com/hyperledger/fabric/bccsp
 github.com/hyperledger/fabric/bccsp/factory


### PR DESCRIPTION
Update Go module dependencies to use fabric v1.4.11 to pull in latest
bccsp updates.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
