### PR TITLE
[FABC-930] Overwrite CN field to allow CSR modification from sdk

### DIFF
--- a/lib/client.go
+++ b/lib/client.go
@@ -555,6 +555,10 @@ func (c *Client) newCertificateRequest(req *api.CSRInfo, id string) *csr.Certifi
 		}
 		cr.KeyRequest = newCfsslBasicKeyRequest(keyRequest)
 
+		if req.CN != "" {
+			cr.CN = req.CN
+		}
+
 		return cr
 	}
 


### PR DESCRIPTION
Signed-off-by: Vieira Neto <vieiranetoc@gmail.com>

Type
######
Lib CSR creation

- Bug fix

#### Description

When coding from fab-sdk-go the function `msp.WithCSR(&msp.CSRInfo{CN: commonName})` has no effect on generated certificate as the lib's function `newCertificateRequest` ignores this field from request. 
My suggestion is to overwrite the CN fields when it exists.

#### Additional details

I'm aiming to write some tests for this change but i couldn't find the correct test to be modified/where to add. Hope someone can help me with this!

#### Related issues

https://jira.hyperledger.org/browse/FABG-1037

#### Release Note
 
- CN field can now be set in lib's api

