### PR TITLE
Enable arm64

### DIFF
--- a/images/fabric-ca/Dockerfile
+++ b/images/fabric-ca/Dockerfile
@@ -12,6 +12,7 @@ ARG GO_TAGS
 
 RUN apk add --no-cache \
 	gcc \
+	binutils-gold \
 	git \
 	musl-dev;
 


### PR DESCRIPTION
Signed-off-by: Ry Jones <ry@linux.com>

#### Type of change

- Improvement

#### Description

binutils-gold adds the missing bits to support building for MacOS ARM

#### Additional details

#### Related issues

