### PR TITLE
[FABC-931] Re-enroll with expired certs 

### DIFF
--- a/cmd/fabric-ca-server/config.go
+++ b/cmd/fabric-ca-server/config.go
@@ -123,6 +123,8 @@ ca:
   certfile:
   # Chain file
   chainfile:
+  # Ignore Certificate Expiration in the case of re-enroll
+  reenrollIgnoreCertExpiry: false
 
 #############################################################################
 #  The gencrl REST endpoint is used to generate a CRL that contains revoked

--- a/docs/source/servercli.rst
+++ b/docs/source/servercli.rst
@@ -20,6 +20,7 @@ Fabric-CA Server's CLI
       -b, --boot string                               The user:pass for bootstrap admin which is required to build default config file
           --ca.certfile string                        PEM-encoded CA certificate file (default "ca-cert.pem")
           --ca.chainfile string                       PEM-encoded CA chain file (default "ca-chain.pem")
+          --ca.ignorecertexpiry                       Ignore Certificate Expirty for re-enroll
           --ca.keyfile string                         PEM-encoded CA key file
       -n, --ca.name string                            Certificate Authority name
           --cacount int                               Number of non-default CA instances

--- a/docs/source/servercli.rst
+++ b/docs/source/servercli.rst
@@ -20,9 +20,9 @@ Fabric-CA Server's CLI
       -b, --boot string                               The user:pass for bootstrap admin which is required to build default config file
           --ca.certfile string                        PEM-encoded CA certificate file (default "ca-cert.pem")
           --ca.chainfile string                       PEM-encoded CA chain file (default "ca-chain.pem")
-          --ca.ignorecertexpiry                       Ignore Certificate Expirty for re-enroll
           --ca.keyfile string                         PEM-encoded CA key file
       -n, --ca.name string                            Certificate Authority name
+          --ca.reenrollignorecertexpiry               Ignore Certificate Expirty for re-enroll
           --cacount int                               Number of non-default CA instances
           --cafiles strings                           A list of comma-separated CA configuration files
           --cfg.affiliations.allowremove              Enables removal of affiliations dynamically

--- a/docs/source/servercli.rst
+++ b/docs/source/servercli.rst
@@ -22,7 +22,7 @@ Fabric-CA Server's CLI
           --ca.chainfile string                       PEM-encoded CA chain file (default "ca-chain.pem")
           --ca.keyfile string                         PEM-encoded CA key file
       -n, --ca.name string                            Certificate Authority name
-          --ca.reenrollignorecertexpiry               Ignore Certificate Expirty for re-enroll
+          --ca.reenrollignorecertexpiry               Ignore Certificate Expiry for re-enroll
           --cacount int                               Number of non-default CA instances
           --cafiles strings                           A list of comma-separated CA configuration files
           --cfg.affiliations.allowremove              Enables removal of affiliations dynamically

--- a/docs/source/serverconfig.rst
+++ b/docs/source/serverconfig.rst
@@ -97,6 +97,8 @@ Fabric-CA Server's Configuration File
       certfile:
       # Chain file
       chainfile:
+      # Ignore Certificate Expiration in the case of re-enroll
+      reenrollIgnoreCertExpiry: false
     
     #############################################################################
     #  The gencrl REST endpoint is used to generate a CRL that contains revoked

--- a/lib/ca.go
+++ b/lib/ca.go
@@ -473,7 +473,7 @@ func (ca *CA) initConfig() (err error) {
 // Return nil if successful; otherwise, return an error.
 func (ca *CA) VerifyCertificate(cert *x509.Certificate, forceTime bool) error {
 
-	log.Debugf("Certicate Dates: NotAfter = %s\n Cert NotBefore = %s \n", cert.NotAfter.String(), cert.NotBefore.String())
+	log.Debugf("Certicate Dates: NotAfter = %s NotBefore = %s \n", cert.NotAfter.String(), cert.NotBefore.String())
 
 	opts, err := ca.getVerifyOptions()
 	if err != nil {

--- a/lib/ca.go
+++ b/lib/ca.go
@@ -471,6 +471,10 @@ func (ca *CA) initConfig() (err error) {
 
 // VerifyCertificate verifies that 'cert' was issued by this CA
 // Return nil if successful; otherwise, return an error.
+// 'forceTime' if false, certificate expiry times will be checked based
+// on the current time.
+// if true, it will force the time to be used to check for expiry to be 30 seconds
+// after the certificate start time.  (this is to support reenrollIgnoreCertExpiry)
 func (ca *CA) VerifyCertificate(cert *x509.Certificate, forceTime bool) error {
 
 	log.Debugf("Certicate Dates: NotAfter = %s NotBefore = %s \n", cert.NotAfter.String(), cert.NotBefore.String())
@@ -480,8 +484,8 @@ func (ca *CA) VerifyCertificate(cert *x509.Certificate, forceTime bool) error {
 		return errors.WithMessage(err, "Failed to get verify options")
 	}
 
-	// force time to be 30seconds after start to ensure expiry doesn't get flaged
-	// this is one of the checks that made on the certificate
+	// force check time to be 30 seconds after certificate start time to ensure expiry doesn't get flagged
+	// this is one of the checks that is made on the certificate in Verify()
 	if forceTime {
 		opts.CurrentTime = cert.NotBefore.Add(time.Duration(time.Second * 30))
 	}

--- a/lib/ca_test.go
+++ b/lib/ca_test.go
@@ -591,14 +591,14 @@ func TestCAVerifyCertificate(t *testing.T) {
 	ca.Config.CA.Keyfile = caKey
 	ca.Config.CA.Certfile = caCert
 	ca.Config.CA.Chainfile = "../testdata/empty.json"
-	err = ca.VerifyCertificate(cert)
+	err = ca.VerifyCertificate(cert, false)
 	t.Log("ca.VerifyCertificate error: ", err)
 	if err == nil {
 		t.Error("VerifyCertificate should have failed")
 	}
 
 	ca.Config.CA.Chainfile = "../testdata/crl.pem"
-	err = ca.VerifyCertificate(cert)
+	err = ca.VerifyCertificate(cert, false)
 	t.Log("ca.VerifyCertificate error: ", err)
 	if err == nil {
 		t.Error("VerifyCertificate should have failed")
@@ -612,7 +612,7 @@ func TestCAVerifyCertificate(t *testing.T) {
 	err = ioutil.WriteFile(filepath.Join(os.TempDir(), "ca-chainfile.pem"), caCert2, 0644)
 	assert.NoError(t, err, "failed to write ca-chainfile.pem")
 	ca.Config.CA.Chainfile = filepath.Join(os.TempDir(), "ca-chainfile.pem")
-	err = ca.VerifyCertificate(cert)
+	err = ca.VerifyCertificate(cert, false)
 	t.Log("ca.VerifyCertificate error: ", err)
 	if err == nil {
 		t.Error("VerifyCertificate should have failed")
@@ -625,13 +625,13 @@ func TestCAVerifyCertificate(t *testing.T) {
 	ca.Config.CA.Chainfile = "doesNotExist"
 	ca.Config.CA.Certfile = "doesNotExist"
 	ca.Config.Intermediate.ParentServer.URL = "http://127.0.0.1:" + caPort
-	err = ca.VerifyCertificate(cert)
+	err = ca.VerifyCertificate(cert, false)
 	t.Log("ca.VerifyCertificate error: ", err)
 	if err == nil {
 		t.Error("VerifyCertificate should have failed")
 	}
 	ca.Config.CA.Chainfile = noUsageCert
-	err = ca.VerifyCertificate(cert)
+	err = ca.VerifyCertificate(cert, false)
 	t.Log("ca.VerifyCertificate error: ", err)
 	if err == nil {
 		t.Error("VerifyCertificate should have failed")

--- a/lib/caconfig.go
+++ b/lib/caconfig.go
@@ -49,6 +49,8 @@ ca:
   certfile: ca-cert.pem
   # The CA key file
   keyfile: ca-key.pem
+  # Ignore Certificate Expiration in the case of re-enroll
+  ignoreCertExpiry: false
 
 #############################################################################
 #  Database section
@@ -116,10 +118,11 @@ type affiliationsOptions struct {
 
 // CAInfo is the CA information on a fabric-ca-server
 type CAInfo struct {
-	Name      string `opt:"n" help:"Certificate Authority name"`
-	Keyfile   string `help:"PEM-encoded CA key file"`
-	Certfile  string `def:"ca-cert.pem" help:"PEM-encoded CA certificate file"`
-	Chainfile string `def:"ca-chain.pem" help:"PEM-encoded CA chain file"`
+	Name             string `opt:"n" help:"Certificate Authority name"`
+	Keyfile          string `help:"PEM-encoded CA key file"`
+	Certfile         string `def:"ca-cert.pem" help:"PEM-encoded CA certificate file"`
+	Chainfile        string `def:"ca-chain.pem" help:"PEM-encoded CA chain file"`
+	IgnoreCertExpiry bool   `def:"false" help:"Ignore Certificate Expirty for re-enroll"`
 }
 
 // CAConfigDB is the database part of the server's config

--- a/lib/caconfig.go
+++ b/lib/caconfig.go
@@ -49,8 +49,6 @@ ca:
   certfile: ca-cert.pem
   # The CA key file
   keyfile: ca-key.pem
-  # Ignore Certificate Expiration in the case of re-enroll
-  ignoreCertExpiry: false
 
 #############################################################################
 #  Database section
@@ -118,11 +116,11 @@ type affiliationsOptions struct {
 
 // CAInfo is the CA information on a fabric-ca-server
 type CAInfo struct {
-	Name             string `opt:"n" help:"Certificate Authority name"`
-	Keyfile          string `help:"PEM-encoded CA key file"`
-	Certfile         string `def:"ca-cert.pem" help:"PEM-encoded CA certificate file"`
-	Chainfile        string `def:"ca-chain.pem" help:"PEM-encoded CA chain file"`
-	IgnoreCertExpiry bool   `def:"false" help:"Ignore Certificate Expirty for re-enroll"`
+	Name                     string `opt:"n" help:"Certificate Authority name"`
+	Keyfile                  string `help:"PEM-encoded CA key file"`
+	Certfile                 string `def:"ca-cert.pem" help:"PEM-encoded CA certificate file"`
+	Chainfile                string `def:"ca-chain.pem" help:"PEM-encoded CA chain file"`
+	ReenrollIgnoreCertExpiry bool   `def:"false" help:"Ignore Certificate Expirty for re-enroll"`
 }
 
 // CAConfigDB is the database part of the server's config

--- a/lib/caconfig.go
+++ b/lib/caconfig.go
@@ -120,7 +120,7 @@ type CAInfo struct {
 	Keyfile                  string `help:"PEM-encoded CA key file"`
 	Certfile                 string `def:"ca-cert.pem" help:"PEM-encoded CA certificate file"`
 	Chainfile                string `def:"ca-chain.pem" help:"PEM-encoded CA chain file"`
-	ReenrollIgnoreCertExpiry bool   `def:"false" help:"Ignore Certificate Expirty for re-enroll"`
+	ReenrollIgnoreCertExpiry bool   `def:"false" help:"Ignore Certificate Expiry for re-enroll"`
 }
 
 // CAConfigDB is the database part of the server's config

--- a/lib/serverrequestcontext.go
+++ b/lib/serverrequestcontext.go
@@ -189,8 +189,11 @@ func (ctx *serverRequestContextImpl) verifyX509Token(ca *CA, authHdr, method, ur
 		return "", caerrors.NewAuthenticationErr(caerrors.ErrInvalidToken, "Invalid token in authorization header: %s", err2)
 	}
 
-	// Make sure the caller's cert was issued by this CA
+	// determine if this being called for a reenroll and the ignore cert expiry property isset
+	// passed to the verify certificate to force it's checking of expiry time to be effectively ignored
 	reenrollIgnoreCertExpiry := ctx.endpoint.Path == "reenroll" && ctx.ca.Config.CA.ReenrollIgnoreCertExpiry
+
+	// Make sure the caller's cert was issued by this CA
 	err2 = ca.VerifyCertificate(cert, reenrollIgnoreCertExpiry)
 	if err2 != nil {
 		return "", caerrors.NewAuthenticationErr(caerrors.ErrUntrustedCertificate, "Untrusted certificate: %s", err2)

--- a/lib/serverrequestcontext.go
+++ b/lib/serverrequestcontext.go
@@ -190,7 +190,8 @@ func (ctx *serverRequestContextImpl) verifyX509Token(ca *CA, authHdr, method, ur
 	}
 
 	// Make sure the caller's cert was issued by this CA
-	err2 = ca.VerifyCertificate(cert, (ctx.endpoint.Path == "reenroll" && ctx.ca.Config.CA.IgnoreCertExpiry))
+	reenrollIgnoreCertExpiry := ctx.endpoint.Path == "reenroll" && ctx.ca.Config.CA.ReenrollIgnoreCertExpiry
+	err2 = ca.VerifyCertificate(cert, reenrollIgnoreCertExpiry)
 	if err2 != nil {
 		return "", caerrors.NewAuthenticationErr(caerrors.ErrUntrustedCertificate, "Untrusted certificate: %s", err2)
 	}
@@ -207,8 +208,8 @@ func (ctx *serverRequestContextImpl) verifyX509Token(ca *CA, authHdr, method, ur
 
 	if expired {
 		log.Debugf("Expired Certificate")
-		if ctx.endpoint.Path == "reenroll" && ctx.ca.Config.CA.IgnoreCertExpiry {
-			log.Infof("Ignoring expired certificate for re-endroll operation")
+		if reenrollIgnoreCertExpiry {
+			log.Infof("Ignoring expired certificate for re-enroll operation")
 		} else {
 			return "", caerrors.NewAuthenticationErr(caerrors.ErrCertExpired,
 				"The certificate in the authorization header is a revoked or expired certificate")

--- a/test/integration/certexpiry/certexpiry_test.go
+++ b/test/integration/certexpiry/certexpiry_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package defserver
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cloudflare/cfssl/config"
+	"github.com/cloudflare/cfssl/log"
+	"github.com/hyperledger/fabric-ca/cmd/fabric-ca-client/command"
+	"github.com/hyperledger/fabric-ca/internal/pkg/util"
+	"github.com/hyperledger/fabric-ca/lib"
+	"github.com/hyperledger/fabric-ca/lib/metadata"
+)
+
+const (
+	cmdName = "fabric-ca-client"
+)
+
+var (
+	defaultServer          *lib.Server
+	defaultServerPort      = 7055
+	defaultServerEnrollURL = fmt.Sprintf("http://admin:adminpw@localhost:%d", defaultServerPort)
+	defaultServerHomeDir   = "certExpiryServerDir"
+	storeCertsDir          = "/tmp/testCertsCertExpiry"
+	clientCAHome           = "/tmp/certExpiryCaHome"
+)
+
+func TestMain(m *testing.M) {
+	var err error
+
+	metadata.Version = "1.1.0"
+	os.Setenv("FABRIC_CA_SERVER_SIGNING_DEFAULT_EXPIRY", "1m")
+	os.Setenv("FABRIC_CA_CLIENT_HOME", clientCAHome)
+
+	os.RemoveAll(defaultServerHomeDir)
+	os.RemoveAll(storeCertsDir)
+	os.RemoveAll(clientCAHome)
+	defaultServer, err = getDefaultServer()
+	if err != nil {
+		log.Errorf("Failed to get instance of server: %s", err)
+		os.Exit(1)
+	}
+
+	err = defaultServer.Start()
+	if err != nil {
+		log.Errorf("Failed to start server: %s", err)
+		os.Exit(1)
+	}
+
+	rc := m.Run()
+
+	err = defaultServer.Stop()
+	if err != nil {
+		log.Errorf("Failed to stop server: %s, integration test results: %d", err, rc)
+		os.Exit(1)
+	}
+
+	os.RemoveAll(defaultServerHomeDir)
+	os.RemoveAll(storeCertsDir)
+	os.RemoveAll(clientCAHome)
+	os.Exit(rc)
+}
+
+func TestReenrollExpiredCert(t *testing.T) {
+	var err error
+
+	// Enroll a user that will be used for subsequent certificate commands
+	err = command.RunMain([]string{cmdName, "enroll", "-u", defaultServerEnrollURL, "-d"})
+	util.FatalError(t, err, "Failed to enroll user")
+
+	// Register a new user
+	err = command.RunMain([]string{cmdName, "register", "-u", defaultServerEnrollURL, "-d", "--csr.keyrequest.reusekey", "--id.name", "user1", "--id.secret", "user1pw", "--id.type", "client"})
+	util.FatalError(t, err, "Failed to register new user1")
+
+	userServiceEnrollURL := fmt.Sprintf("http://user1:user1pw@localhost:%d", defaultServerPort)
+
+	// Enroll and then reenroll to check
+	err = command.RunMain([]string{cmdName, "enroll", "-u", userServiceEnrollURL, "-d"})
+	util.FatalError(t, err, "Failed to enroll user1")
+
+	err = command.RunMain([]string{cmdName, "reenroll", "-u", userServiceEnrollURL, "-d", "--csr.keyrequest.reusekey"})
+	util.FatalError(t, err, "Failed to reenroll user1")
+
+	log.Infof("Tested re-enroll of id, waiting for cert to expiry before testing re-enroll\n")
+	time.Sleep(2 * time.Minute)
+
+	// within the setting in the CA config reenrollIgnoreCertExpiry this call would normally fail
+	err = command.RunMain([]string{cmdName, "reenroll", "-u", userServiceEnrollURL, "-d", "--csr.keyrequest.reusekey"})
+	util.FatalError(t, err, "Failed to reenroll user1 %s", time.Now())
+}
+
+func getDefaultServer() (*lib.Server, error) {
+	affiliations := map[string]interface{}{
+		"hyperledger": map[string]interface{}{
+			"fabric":    []string{"ledger", "orderer", "security"},
+			"fabric-ca": nil,
+			"sdk":       nil,
+		},
+		"org2":      []string{"dept1"},
+		"org1":      nil,
+		"org2dept1": nil,
+	}
+	profiles := map[string]*config.SigningProfile{
+		"tls": &config.SigningProfile{
+			Usage:        []string{"signing", "key encipherment", "server auth", "client auth", "key agreement"},
+			ExpiryString: "1m",
+		},
+		"ca": &config.SigningProfile{
+			Usage:        []string{"cert sign", "crl sign"},
+			ExpiryString: "1m",
+			CAConstraint: config.CAConstraint{
+				IsCA:       true,
+				MaxPathLen: 0,
+			},
+		},
+	}
+	defaultProfile := &config.SigningProfile{
+		Usage:        []string{"cert sign"},
+		ExpiryString: "1m",
+		Expiry:       time.Minute * 1, // set to force certs to expiry quickly
+	}
+	srv := &lib.Server{
+		Config: &lib.ServerConfig{
+			Port:  defaultServerPort,
+			Debug: true,
+		},
+		CA: lib.CA{
+			Config: &lib.CAConfig{
+				Intermediate: lib.IntermediateCA{
+					ParentServer: lib.ParentServer{
+						URL: "",
+					},
+				},
+				CA: lib.CAInfo{
+					ReenrollIgnoreCertExpiry: true,
+				},
+				Affiliations: affiliations,
+				Registry: lib.CAConfigRegistry{
+					MaxEnrollments: -1,
+				},
+				Signing: &config.Signing{
+					Profiles: profiles,
+					Default:  defaultProfile,
+				},
+				Version: "1.1.0", // The default test server/ca should use the latest version
+			},
+		},
+		HomeDir: defaultServerHomeDir,
+	}
+	// The bootstrap user's affiliation is the empty string, which
+	// means the user is at the affiliation root
+	err := srv.RegisterBootstrapUser("admin", "adminpw", "")
+	if err != nil {
+		return nil, err
+	}
+	return srv, nil
+}


### PR DESCRIPTION
#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)
- Documentation update

#### Description

Resolves to https://jira.hyperledger.org/browse/FABC-931.
New config option to allow for certificate expiry to be ignored in the case of a re-enroll of an id. But only in the re-enroll case.


