### PR TITLE
Update CI Pool Image

### DIFF
--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -22,13 +22,13 @@ stages:
         strategy:
           matrix:
             Linux:
-              IMAGE: ubuntu-20.04
+              IMAGE: ubuntu-latest
               TARGET: linux
             Mac:
-              IMAGE: macOS-10.15
+              IMAGE: macOS-latest
               TARGET: darwin
             Windows:
-              IMAGE: windows-2019
+              IMAGE: windows-latest
               TARGET: windows
         pool:
           vmImage: $(IMAGE)
@@ -51,7 +51,7 @@ stages:
     jobs:
       - job: Docker
         pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-latest
         steps:
           - template: install_deps.yml
           - checkout: self
@@ -71,7 +71,7 @@ stages:
     jobs:
       - job: Release
         pool:
-          vmImage: ubuntu-20.04
+          vmImage: ubuntu-latest
         steps:
           - download: current
             patterns: '*.tar.gz'

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 jobs:
 - job: VerifyBuild
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   steps:
   - template: install_deps.yml
   - checkout: self
@@ -27,7 +27,7 @@ jobs:
 
 - job: FVTTests
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   steps:
   - template: install_deps.yml
   - checkout: self
@@ -38,7 +38,7 @@ jobs:
 
 - job: DocBuild
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   container:
     image: n42org/tox:3.4.0
   steps:


### PR DESCRIPTION
Ubuntu 16.04 is deprecate and will be removed from the CI pools soon. Upgrade to the latest version.

Signed-off-by: Brett Logan <lindluni@github.com>
