### PR TITLE
Bump Go to 1.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ PKGNAME = github.com/hyperledger/$(PROJECT_NAME)
 
 METADATA_VAR = Version=$(PROJECT_VERSION)
 
-GO_VER = 1.16.7
+GO_VER = 1.17.0
 GO_SOURCE := $(shell find . -name '*.go')
 GO_LDFLAGS = $(patsubst %,-X $(PKGNAME)/lib/metadata.%,$(METADATA_VAR))
 export GO_LDFLAGS

--- a/ci/azure-pipelines-release.yml
+++ b/ci/azure-pipelines-release.yml
@@ -11,7 +11,7 @@ variables:
   - name: GOPATH
     value: $(Agent.BuildDirectory)/go
   - name: GOVER
-    value: 1.16.7
+    value: 1.17
 
 stages:
   - stage: BuildBinaries

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
 variables:
   GOPATH: $(Agent.BuildDirectory)/go
   PATH: $(Agent.BuildDirectory)/go/bin:$(Agent.BuildDirectory)/go/src/github.com/hyperledger/fabric-ca/build/tools:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GOVER: 1.16.7
+  GOVER: 1.17
 
 jobs:
 - job: VerifyBuild

--- a/internal/pkg/util/configurebccsp.go
+++ b/internal/pkg/util/configurebccsp.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/internal/pkg/util/configurebccsp_test.go
+++ b/internal/pkg/util/configurebccsp_test.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/internal/pkg/util/configurebccspnopkcs11.go
+++ b/internal/pkg/util/configurebccspnopkcs11.go
@@ -1,3 +1,4 @@
+//go:build !pkcs11
 // +build !pkcs11
 
 /*

--- a/lib/capkcs11_test.go
+++ b/lib/capkcs11_test.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/lib/keyrequest.go
+++ b/lib/keyrequest.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/lib/keyrequestnopkcs11.go
+++ b/lib/keyrequestnopkcs11.go
@@ -1,3 +1,4 @@
+//go:build !pkcs11
 // +build !pkcs11
 
 /*

--- a/lib/server/db/sqlite/driver.go
+++ b/lib/server/db/sqlite/driver.go
@@ -1,3 +1,4 @@
+//go:build !caclient
 // +build !caclient
 
 /*

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*


### PR DESCRIPTION
#### Type of change
- Improvement (improvement to code, performance, etc)

#### Description

Bump Go version to 1.17.0. The current version 1.15.x is end of life and contains multiple vulnerabilities.

#### Additional details

This fixes CVE-2021-27918, CVE-2021-27919, CVE-2021-31525, CVE-2021-33195,
CVE-2021-33196, CVE-2021-33197, CVE-2021-33198, CVE-2021-34558,
CVE-2021-36221 and CVE-2021-29923. CVE-2021-29923 is not backported to any version < 1.17.0.

#### Related issues

n/a

#### Release Note

Fabric CA v1.5.x includes updated Go dependencies.
