### PR TITLE
Release commit for v1.5.2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PROJECT_NAME = fabric-ca
 ALPINE_VER ?= 3.14
 DEBIAN_VER ?= stretch
 BASE_VERSION = 1.5.2
-IS_RELEASE = false
+IS_RELEASE = true
 
 ARCH=$(shell go env GOARCH)
 MARCH=$(shell go env GOOS)-$(shell go env GOARCH)

--- a/release_notes/v1.5.2.md
+++ b/release_notes/v1.5.2.md
@@ -1,0 +1,41 @@
+v1.5.2 Release Notes - September 8, 2021
+========================================
+
+Release v1.5.2 updates Fabric CA to be compatible with Go 1.16.7.
+
+Dependencies
+------------
+
+Fabric CA v1.5.2 has been tested with the following dependencies:
+- Go 1.16.7
+- Alpine 3.14 (for Docker images)
+
+
+Changes, Known Issues, and Workarounds
+--------------------------------------
+None.
+
+Known Vulnerabilities
+---------------------
+- FABC-174 Commands can be manipulated to delete identities or affiliations
+
+  This vulnerability can be resolved in one of two ways:
+
+  1) Use HTTPS (TLS) so that the authorization header is not in clear text.
+
+  2) The token generation/authentication mechanism was improved to optionally prevent
+  token reuse. As of v1.4 a more secure token can be used by setting environment variable:
+
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false
+
+  However, it cannot be set to false until all clients have
+  been updated to generate the more secure token and tolerate
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false.
+  The Fabric CA client has been updated in v1.4 to generate the more secure token.
+  The Fabric SDKs will be updated by v2.0 timeframe to generate the more secure token,
+  at which time the default for Fabric CA server will change to:
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false
+
+Resolved Vulnerabilities
+------------------------
+None.


### PR DESCRIPTION
Add release notes for v1.5.2.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>