### PR TITLE
Fixes for CA deployment guide

### DIFF
--- a/cmd/fabric-ca-server/config.go
+++ b/cmd/fabric-ca-server/config.go
@@ -335,6 +335,8 @@ signing:
 #  3) pathlength == 0 means a limit of 0 is requested;
 #     this is the default for an intermediate CA, which means it can not issue
 #     CA certificates though it can still issue end entity certificates.
+#  The "hosts" field will be used to specify Subject Alternative Names
+#  if the server creates a self-signed TLS certificate.
 ###########################################################################
 csr:
    cn: <<<COMMONNAME>>>

--- a/docs/source/serverconfig.rst
+++ b/docs/source/serverconfig.rst
@@ -40,25 +40,25 @@ Fabric-CA Server's Configuration File
     #   of this configuration file.
     #
     #############################################################################
-    
+
     # Version of config file
     version: <<<VERSION>>>
-    
+
     # Server's listening port (default: 7054)
     port: 7054
-    
+
     # Cross-Origin Resource Sharing (CORS)
     cors:
         enabled: false
         origins:
           - "*"
-    
+
     # Enables debug logging (default: false)
     debug: false
-    
+
     # Size limit of an acceptable CRL in bytes (default: 512000)
     crlsizelimit: 512000
-    
+
     #############################################################################
     #  TLS section for the server's listening port
     #
@@ -78,7 +78,7 @@ Fabric-CA Server's Configuration File
       clientauth:
         type: noclientcert
         certfiles:
-    
+
     #############################################################################
     #  The CA section contains information related to the Certificate Authority
     #  including the name of the CA, which should be unique for all members
@@ -99,7 +99,7 @@ Fabric-CA Server's Configuration File
       chainfile:
       # Ignore Certificate Expiration in the case of re-enroll
       reenrollIgnoreCertExpiry: false
-    
+
     #############################################################################
     #  The gencrl REST endpoint is used to generate a CRL that contains revoked
     #  certificates. This section contains configuration options that are used
@@ -110,7 +110,7 @@ Fabric-CA Server's Configuration File
       # specified by this property is added to the UTC time, the resulting time
       # is used to set the 'Next Update' date of the CRL.
       expiry: 24h
-    
+
     #############################################################################
     #  The registry section controls how the fabric-ca-server does two things:
     #  1) authenticates enrollment requests which contain a username and password
@@ -130,7 +130,7 @@ Fabric-CA Server's Configuration File
       # Maximum number of times a password/secret can be reused for enrollment
       # (default: -1, which means there is no limit)
       maxenrollments: -1
-    
+
       # Contains identity information which is used when LDAP is disabled
       identities:
          - name: <<<adminUserName>>>
@@ -145,7 +145,7 @@ Fabric-CA Server's Configuration File
               hf.GenCRL: true
               hf.Registrar.Attributes: "*"
               hf.AffiliationMgr: true
-    
+
     #############################################################################
     #  Database section
     #  Supported types are: "sqlite3", "postgres", and "mysql".
@@ -165,7 +165,7 @@ Fabric-CA Server's Configuration File
           client:
             certfile:
             keyfile:
-    
+
     #############################################################################
     #  LDAP section
     #  If LDAP is enabled, the fabric-ca-server calls LDAP to:
@@ -225,7 +225,7 @@ Fabric-CA Server's Configuration File
              groups:
                 - name:
                   value:
-    
+
     #############################################################################
     # Affiliations section. Fabric CA server can be bootstrapped with the
     # affiliations specified in this section. Affiliations are specified as maps.
@@ -252,7 +252,7 @@ Fabric-CA Server's Configuration File
           - department2
        org2:
           - department1
-    
+
     #############################################################################
     #  Signing section
     #
@@ -291,7 +291,7 @@ Fabric-CA Server's Configuration File
                 - client auth
                 - key agreement
              expiry: 8760h
-    
+
     ###########################################################################
     #  Certificate Signing Request (CSR) section.
     #  This controls the creation of the root CA certificate.
@@ -309,6 +309,8 @@ Fabric-CA Server's Configuration File
     #  3) pathlength == 0 means a limit of 0 is requested;
     #     this is the default for an intermediate CA, which means it can not issue
     #     CA certificates though it can still issue end entity certificates.
+    #  The "hosts" field will be used to specify Subject Alternative Names
+    #  if the server creates a self-signed TLS certificate.
     ###########################################################################
     csr:
        cn: <<<COMMONNAME>>>
@@ -327,7 +329,7 @@ Fabric-CA Server's Configuration File
        ca:
           expiry: 131400h
           pathlength: <<<PATHLENGTH>>>
-    
+
     ###########################################################################
     # Each CA can issue both X509 enrollment certificate as well as Idemix
     # Credential. This section specifies configuration for the issuer component
@@ -341,17 +343,17 @@ Fabric-CA Server's Configuration File
       # A revocation handle and credential revocation information (CRI) are used to create non revocation proof
       # by the prover to prove to the verifier that her credential is not revoked.
       rhpoolsize: 1000
-    
+
       # The Idemix credential issuance is a two step process. First step is to  get a nonce from the issuer
       # and second step is send credential request that is constructed using the nonce to the isuser to
       # request a credential. This configuration property specifies expiration for the nonces. By default is
       # nonces expire after 15 seconds. The value is expressed in the time.Duration format (see https://golang.org/pkg/time/#ParseDuration).
       nonceexpiration: 15s
-    
+
       # Specifies interval at which expired nonces are removed from datastore. Default value is 15 minutes.
       #  The value is expressed in the time.Duration format (see https://golang.org/pkg/time/#ParseDuration)
       noncesweepinterval: 15m
-    
+
     #############################################################################
     # BCCSP (BlockChain Crypto Service Provider) section is used to select which
     # crypto library implementation to use
@@ -364,7 +366,7 @@ Fabric-CA Server's Configuration File
             filekeystore:
                 # The directory used for the software file-based keystore
                 keystore: msp/keystore
-    
+
     #############################################################################
     # Multi CA section
     #
@@ -391,11 +393,11 @@ Fabric-CA Server's Configuration File
     # --cafiles ca/ca2/fabric-ca-server-config.yaml
     #
     #############################################################################
-    
+
     cacount:
-    
+
     cafiles:
-    
+
     #############################################################################
     # Intermediate CA section
     #
@@ -430,18 +432,18 @@ Fabric-CA Server's Configuration File
       parentserver:
         url:
         caname:
-    
+
       enrollment:
         hosts:
         profile:
         label:
-    
+
       tls:
         certfiles:
         client:
           certfile:
           keyfile:
-    
+
     #############################################################################
     # CA configuration section
     #
@@ -453,7 +455,7 @@ Fabric-CA Server's Configuration File
     cfg:
       identities:
         passwordattempts: 10
-    
+
     ###############################################################################
     #
     #    Operations section
@@ -462,27 +464,27 @@ Fabric-CA Server's Configuration File
     operations:
         # host and port for the operations server
         listenAddress: 127.0.0.1:9443
-    
+
         # TLS configuration for the operations endpoint
         tls:
             # TLS enabled
             enabled: false
-    
+
             # path to PEM encoded server certificate for the operations server
             cert:
                 file:
-    
+
             # path to PEM encoded server key for the operations server
             key:
                 file:
-    
+
             # require client certificate authentication to access all resources
             clientAuthRequired: false
-    
+
             # paths to PEM encoded ca certificates to trust for client authentication
             clientRootCAs:
                 files: []
-    
+
     ###############################################################################
     #
     #    Metrics section
@@ -491,18 +493,18 @@ Fabric-CA Server's Configuration File
     metrics:
         # statsd, prometheus, or disabled
         provider: disabled
-    
+
         # statsd configuration
         statsd:
             # network type: tcp or udp
             network: udp
-    
+
             # statsd server address
             address: 127.0.0.1:8125
-    
+
             # the interval at which locally cached counters and gauges are pushed
             # to statsd; timings are pushed immediately
             writeInterval: 10s
-    
+
             # prefix is prepended to all emitted statsd metrics
             prefix: server


### PR DESCRIPTION
Fix and improve instructions related to csr.hosts in the CA
config and deployment guide.
Also update deployment guide to clarify TLS certs and bootstrap
identity for TLS CA server organization CA server.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>