### PR TITLE
Bump fvt mysql to 0.8.22-1

### DIFF
--- a/images/fabric-ca-fvt/payload/mysql_setup.sh
+++ b/images/fabric-ca-fvt/payload/mysql_setup.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
 RC=0
 arch=$(uname -m)
 
 export DEBIAN_FRONTEND=noninteractive
+
+# Latest mysql version number can be found at https://dev.mysql.com/downloads/repo/apt/
 echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | debconf-set-selections
-wget https://dev.mysql.com/get/mysql-apt-config_0.8.13-1_all.deb
-dpkg -i mysql-apt-config_0.8.13-1_all.deb
+wget https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb
+dpkg -i mysql-apt-config_0.8.22-1_all.deb
 apt-get update
 apt-get install mysql-server -y
 service mysql start


### PR DESCRIPTION
Bump fvt mysql to 0.8.22-1 to fix FVT docker image build.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
