### PR TITLE
Wrong path in operations guide of /docs

### DIFF
--- a/docs/source/operations_guide.rst
+++ b/docs/source/operations_guide.rst
@@ -621,7 +621,7 @@ Enroll Peer2
 
 You will issue the commands below to get Peer2 enrolled. In the commands below,
 we will assume the trusted root certificate of Org2 is available at
-``/tmp/hyperledger/org2/peer2/tls/org2-ca-cert.pem`` on Peer2's host machine.
+``/tmp/hyperledger/org2/peer2/assets/ca/org2-ca-cert.pem`` on Peer2's host machine.
 
 .. code:: bash
 


### PR DESCRIPTION
#### Type of change

- Bug fix
- Documentation update

#### Description

Certificate has to be copied to Peer2's CA component
