### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -46,16 +46,7 @@ func TestClientConfigStat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get cwd: %s", err)
 	}
-	td, err := ioutil.TempDir("", "ClientConfigStat")
-	if err != nil {
-		t.Fatalf("failed to get tmp dir: %s", err)
-	}
-	defer func() {
-		err = os.RemoveAll(td)
-		if err != nil {
-			t.Errorf("RemoveAll failed: %s", err)
-		}
-	}()
+	td := t.TempDir()
 	err = os.Chdir(td)
 	if err != nil {
 		t.Fatalf("failed to cd to %v: %s", td, err)
@@ -1474,14 +1465,11 @@ func TestGenCSR(t *testing.T) {
 // Test to make sure that once an identity is revoked, all subsequent commands
 // invoked by revoked user should be rejected by server for all its issued certificates
 func TestRevokedIdentity(t *testing.T) {
-	testHome, err := ioutil.TempDir(".", "revoketesthome")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
+	testHome := t.TempDir()
 	serverdir := filepath.Join(testdataDir, "server")
 
 	srv := TestGetServer(ctport1, serverdir, "", -1, t)
-	err = srv.Start()
+	err := srv.Start()
 	if err != nil {
 		t.Fatalf("Failed to start server: %s", err)
 	}

--- a/lib/client_whitebox_test.go
+++ b/lib/client_whitebox_test.go
@@ -9,7 +9,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -562,16 +561,7 @@ func TestCWBCAConfigStat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get cwd: %s", err)
 	}
-	td, err := ioutil.TempDir("", "CAConfigStat")
-	if err != nil {
-		t.Fatalf("failed to get tmp dir: %s", err)
-	}
-	defer func() {
-		err = os.RemoveAll(td)
-		if err != nil {
-			t.Errorf("RemoveAll failed: %s", err)
-		}
-	}()
+	td := t.TempDir()
 	err = os.Chdir(td)
 	if err != nil {
 		t.Fatalf("failed to cd to %v: %s", td, err)

--- a/lib/server/idemix/issuer_test.go
+++ b/lib/server/idemix/issuer_test.go
@@ -11,7 +11,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,12 +39,8 @@ func TestNewIssuer(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerinittest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	testdir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -89,12 +84,8 @@ func TestInitDBNotInitialized(t *testing.T) {
 }
 
 func TestInitExistingIssuerCredential(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerinittest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	testdir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -131,15 +122,11 @@ func TestInitExistingIssuerCredential(t *testing.T) {
 	assert.NoError(t, err)
 }
 func TestInitRenewTrue(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerinittest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 	db, issuer := getIssuer(t, testdir, true, false)
 	assert.NotNil(t, issuer)
 
-	err = issuer.Init(true, db, &dbutil.Levels{Credential: 1, RAInfo: 1, Nonce: 1})
+	err := issuer.Init(true, db, &dbutil.Levels{Credential: 1, RAInfo: 1, Nonce: 1})
 	assert.Error(t, err, "Init should fail if it fails to generate random number")
 
 	db, issuer = getIssuer(t, testdir, false, true)
@@ -170,13 +157,9 @@ func TestInitRenewTrue(t *testing.T) {
 }
 
 func TestVerifyTokenError(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "verifytokentesterror")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -214,13 +197,9 @@ func TestVerifyTokenError(t *testing.T) {
 }
 
 func TestVerifyTokenNoCreds(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "verifytokentestnocreds")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -250,13 +229,9 @@ func TestVerifyTokenNoCreds(t *testing.T) {
 }
 
 func TestVerifyTokenBadSignatureEncoding(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "verifytokentestbadsigencoding")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -287,13 +262,9 @@ func TestVerifyTokenBadSignatureEncoding(t *testing.T) {
 }
 
 func TestVerifyTokenBadSignature(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "verifytokentestbadsig")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -340,13 +311,9 @@ func TestIsToken(t *testing.T) {
 }
 
 func TestRevocationPublicKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "revocationpubkeytest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}

--- a/lib/server/idemix/issuer_whitebox_test.go
+++ b/lib/server/idemix/issuer_whitebox_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package idemix
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,12 +23,8 @@ const (
 
 // TestIssuer tests issuer
 func TestIssuer(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerinittest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	testdir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -68,12 +63,8 @@ func TestIssuer(t *testing.T) {
 }
 
 func TestIssuerPublicKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerinittest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
-	err = os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
+	testdir := t.TempDir()
+	err := os.MkdirAll(filepath.Join(testdir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}

--- a/lib/server/idemix/issuercredential_test.go
+++ b/lib/server/idemix/issuercredential_test.go
@@ -27,15 +27,11 @@ const (
 )
 
 func TestLoadEmptyIdemixPublicKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerkeyloadTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
+	testdir := t.TempDir()
 	pubkeyfile, err := ioutil.TempFile(testdir, "IdemixPublicKey")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err.Error())
 	}
-	defer os.RemoveAll(testdir)
 	idemixLib := new(mocks.Lib)
 	ic := NewIssuerCredential(pubkeyfile.Name(), testSecretKeyFile, idemixLib)
 	err = ic.Load()
@@ -46,10 +42,7 @@ func TestLoadEmptyIdemixPublicKey(t *testing.T) {
 }
 
 func TestLoadFakeIdemixPublicKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerkeyloadTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
+	testdir := t.TempDir()
 	pubkeyfile, err := ioutil.TempFile(testdir, "IdemixPublicKey")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err.Error())
@@ -58,7 +51,6 @@ func TestLoadFakeIdemixPublicKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err.Error())
 	}
-	defer os.RemoveAll(testdir)
 	_, err = pubkeyfile.WriteString("foo")
 	if err != nil {
 		t.Fatalf("Failed to write to the file %s", pubkeyfile.Name())
@@ -73,15 +65,11 @@ func TestLoadFakeIdemixPublicKey(t *testing.T) {
 }
 
 func TestLoadEmptyIdemixSecretKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerkeyloadTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
+	testdir := t.TempDir()
 	privkeyfile, err := ioutil.TempFile(testdir, "IdemixSecretKey")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err.Error())
 	}
-	defer os.RemoveAll(testdir)
 	idemixLib := new(mocks.Lib)
 	ik := NewIssuerCredential(testPublicKeyFile, privkeyfile.Name(), idemixLib)
 	err = ik.Load()
@@ -92,14 +80,10 @@ func TestLoadEmptyIdemixSecretKey(t *testing.T) {
 }
 
 func TestLoadNonExistentIdemixSecretKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerkeyloadTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 	idemixLib := new(mocks.Lib)
 	ik := NewIssuerCredential(testPublicKeyFile, filepath.Join(testdir, "IdemixSecretKey"), idemixLib)
-	err = ik.Load()
+	err := ik.Load()
 	assert.Error(t, err, "Should have failed to load non existing issuer secret key")
 	if err != nil {
 		assert.Contains(t, err.Error(), "Failed to read Issuer secret key")
@@ -138,11 +122,7 @@ func TestStoreNilIdemixPublicKey(t *testing.T) {
 }
 
 func TestStoreReadonlyPublicKeyFilePath(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerpubkeytest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
 	pubkeyfile := path.Join(testdir, "testdata1/IdemixPublicKey")
 
@@ -173,11 +153,7 @@ func TestStoreReadonlyPublicKeyFilePath(t *testing.T) {
 }
 
 func TestStoreReadonlySecretKeyFilePath(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "issuerkeystoreTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
 	// foo directory is non-existent
 	privkeyfile := filepath.Join(testdir, "foo/IdemixSecretKey")

--- a/lib/server/idemix/revocationauthority_test.go
+++ b/lib/server/idemix/revocationauthority_test.go
@@ -9,7 +9,6 @@ package idemix_test
 import (
 	"bytes"
 	"crypto/ecdsa"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -43,12 +42,8 @@ func TestLongTermKeyError(t *testing.T) {
 	}
 }
 func TestRevocationKeyLoadError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "revokekeyloaderrortest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
-	err = os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
+	homeDir := t.TempDir()
+	err := os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -80,12 +75,8 @@ func TestRevocationKeyLoadError(t *testing.T) {
 }
 
 func TestGetRAInfoFromDBError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "rainfodberrortest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
-	err = os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
+	homeDir := t.TempDir()
+	err := os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -111,12 +102,8 @@ func TestGetRAInfoFromDBError(t *testing.T) {
 }
 
 func TestGetRAInfoFromNewDBSelectError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "rainfodberrortest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
-	err = os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
+	homeDir := t.TempDir()
+	err := os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -143,12 +130,8 @@ func TestGetRAInfoFromNewDBSelectError(t *testing.T) {
 }
 
 func TestGetRAInfoFromExistingDB(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "newraexistingdbtest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
-	err = os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
+	homeDir := t.TempDir()
+	err := os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
@@ -182,11 +165,7 @@ func TestGetRAInfoFromExistingDB(t *testing.T) {
 }
 
 func TestRevocationKeyStoreFailure(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "rkstoretesthome")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	issuer, db, _ := setupForInsertTests(t, homeDir)
 	os.RemoveAll(path.Join(homeDir, "msp/keystore"))
 	rainfo := RevocationAuthorityInfo{
@@ -200,7 +179,7 @@ func TestRevocationKeyStoreFailure(t *testing.T) {
 	db.On("NamedExec", InsertRAInfo, &rainfo).Return(result, nil)
 	issuer.On("DB").Return(db)
 	keystoreDir := path.Join(homeDir, "msp/keystore")
-	err = os.MkdirAll(keystoreDir, 4444)
+	err := os.MkdirAll(keystoreDir, 4444)
 	if err != nil {
 		t.Fatalf("Failed to create read only directory: %s", err.Error())
 	}
@@ -215,11 +194,7 @@ func TestRevocationKeyStoreFailure(t *testing.T) {
 }
 
 func TestGetRAInfoFromNewDBInsertFailure(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "rainfoinserttest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	issuer, db, _ := setupForInsertTests(t, homeDir)
 	rainfo := RevocationAuthorityInfo{
 		Epoch:                1,
@@ -234,7 +209,7 @@ func TestGetRAInfoFromNewDBInsertFailure(t *testing.T) {
 	opts := &Config{RHPoolSize: 100, RevocationPublicKeyfile: path.Join(homeDir, DefaultRevocationPublicKeyFile),
 		RevocationPrivateKeyfile: path.Join(homeDir, "msp/keystore", DefaultRevocationPrivateKeyFile)}
 	issuer.On("Config").Return(opts)
-	_, err = NewRevocationAuthority(issuer, 1)
+	_, err := NewRevocationAuthority(issuer, 1)
 	assert.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "Failed to insert the revocation authority info record; no rows affected")
@@ -242,15 +217,11 @@ func TestGetRAInfoFromNewDBInsertFailure(t *testing.T) {
 }
 
 func TestGetRAInfoFromNewDBInsertFailure1(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "rainfoinserttest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	err = os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
+	homeDir := t.TempDir()
+	err := os.MkdirAll(path.Join(homeDir, "msp/keystore"), 0777)
 	if err != nil {
 		t.Fatalf("Failed to create directory: %s", err.Error())
 	}
-	defer os.RemoveAll(homeDir)
 	issuer, db, _ := setupForInsertTests(t, homeDir)
 	rainfo := RevocationAuthorityInfo{
 		Epoch:                1,
@@ -273,11 +244,7 @@ func TestGetRAInfoFromNewDBInsertFailure1(t *testing.T) {
 }
 
 func TestGetRAInfoFromNewDBInsertError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "rainfoinserttest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	issuer, db, _ := setupForInsertTests(t, homeDir)
 	rainfo := RevocationAuthorityInfo{
 		Epoch:                1,
@@ -291,7 +258,7 @@ func TestGetRAInfoFromNewDBInsertError(t *testing.T) {
 	opts := &Config{RHPoolSize: 100, RevocationPublicKeyfile: path.Join(homeDir, DefaultRevocationPublicKeyFile),
 		RevocationPrivateKeyfile: path.Join(homeDir, "msp/keystore", DefaultRevocationPrivateKeyFile)}
 	issuer.On("Config").Return(opts)
-	_, err = NewRevocationAuthority(issuer, 1)
+	_, err := NewRevocationAuthority(issuer, 1)
 	assert.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "Failed to insert revocation authority info into database")
@@ -299,11 +266,7 @@ func TestGetRAInfoFromNewDBInsertError(t *testing.T) {
 }
 
 func TestGetNewRevocationHandleSelectError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "selecterrortest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 	selectFnc := getSelectFunc(t, true, false)
 	ra := getRevocationAuthority(t, "GetNextRevocationHandle", homeDir, db, nil, 0, false, false, selectFnc)
@@ -320,7 +283,7 @@ func TestGetNewRevocationHandleSelectError(t *testing.T) {
 	tx.On("Select", "GetNextRevocationHandle", &rcInfos, SelectRAInfo).Return(fnc)
 
 	db.On("BeginTx").Return(tx)
-	_, err = ra.GetNewRevocationHandle()
+	_, err := ra.GetNewRevocationHandle()
 	assert.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "Failed to get revocation authority info from database")
@@ -328,11 +291,7 @@ func TestGetNewRevocationHandleSelectError(t *testing.T) {
 }
 
 func TestGetNewRevocationHandleNoData(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "rhnodatatest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 	selectFnc := getSelectFunc(t, true, false)
 	ra := getRevocationAuthority(t, "GetRAInfo", homeDir, db, nil, 0, false, false, selectFnc)
@@ -348,7 +307,7 @@ func TestGetNewRevocationHandleNoData(t *testing.T) {
 	tx.On("Select", "GetRAInfo", &rcInfos, SelectRAInfo).Return(fnc)
 
 	db.On("BeginTx").Return(tx)
-	_, err = ra.GetNewRevocationHandle()
+	_, err := ra.GetNewRevocationHandle()
 	assert.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "No revocation authority info found in database")
@@ -356,11 +315,7 @@ func TestGetNewRevocationHandleNoData(t *testing.T) {
 }
 
 func TestGetNewRevocationHandleExecError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "nextrhexecerrortest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 	selectFnc := getSelectFunc(t, true, false)
 	ra := getRevocationAuthority(t, "GetRAInfo", homeDir, db, nil, 0, false, false, selectFnc)
@@ -376,7 +331,7 @@ func TestGetNewRevocationHandleExecError(t *testing.T) {
 	tx.On("Rollback", "GetNextRevocationHandle").Return(nil)
 
 	db.On("BeginTx").Return(tx)
-	_, err = ra.GetNewRevocationHandle()
+	_, err := ra.GetNewRevocationHandle()
 	assert.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "Failed to update revocation authority info")
@@ -384,11 +339,7 @@ func TestGetNewRevocationHandleExecError(t *testing.T) {
 }
 
 func TestGetNewRevocationHandleRollbackError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "nextrhrollbackerrortest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 	selectFnc := getSelectFunc(t, true, false)
 	ra := getRevocationAuthority(t, "GetRAInfo", homeDir, db, nil, 0, false, false, selectFnc)
@@ -404,7 +355,7 @@ func TestGetNewRevocationHandleRollbackError(t *testing.T) {
 	tx.On("Rollback", "GetNextRevocationHandle").Return(errors.New("Rollback error"))
 
 	db.On("BeginTx").Return(tx)
-	_, err = ra.GetNewRevocationHandle()
+	_, err := ra.GetNewRevocationHandle()
 	assert.Error(t, err)
 	if err != nil {
 		assert.Contains(t, err.Error(), "Error encountered while rolling back transaction")
@@ -412,11 +363,7 @@ func TestGetNewRevocationHandleRollbackError(t *testing.T) {
 }
 
 func TestGetNewRevocationHandleCommitError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "nextrhcommiterrortest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 	selectFnc := getSelectFunc(t, true, false)
 	ra := getRevocationAuthority(t, "GetRAInfo", homeDir, db, nil, 0, false, false, selectFnc)
@@ -432,17 +379,13 @@ func TestGetNewRevocationHandleCommitError(t *testing.T) {
 	tx.On("Select", "GetRAInfo", &rcInfos, SelectRAInfo).Return(f1)
 
 	db.On("BeginTx").Return(tx)
-	_, err = ra.GetNewRevocationHandle()
+	_, err := ra.GetNewRevocationHandle()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Error encountered while committing transaction")
 }
 
 func TestGetNewRevocationHandle(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "nextrhtest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 	selectFnc := getSelectFunc(t, true, false)
 	rc := getRevocationAuthority(t, "GetRAInfo", homeDir, db, nil, 0, false, false, selectFnc)
@@ -464,11 +407,7 @@ func TestGetNewRevocationHandle(t *testing.T) {
 }
 
 func TestGetNewRevocationHandleLastHandle(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "nextlastrhtest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 	selectFnc := getSelectFunc(t, true, false)
 	ra := getRevocationAuthority(t, "GetRAInfo", homeDir, db, nil, 0, false, false, selectFnc)
@@ -493,11 +432,7 @@ func TestGetNewRevocationHandleLastHandle(t *testing.T) {
 }
 
 func TestGetEpoch(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "getepochtest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 	selectFnc := getSelectFunc(t, true, false)
 	ra := getRevocationAuthority(t, "GetRAInfo", homeDir, db, nil, 0, false, false, selectFnc)
@@ -512,11 +447,7 @@ func TestGetEpoch(t *testing.T) {
 }
 
 func TestGetEpochRAInfoError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "createcritest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 
 	revocationKey, err := idemix.GenerateLongTermRevocationKey()
@@ -530,11 +461,7 @@ func TestGetEpochRAInfoError(t *testing.T) {
 }
 
 func TestCreateCRIGetRAInfoError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "createcritest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 
 	revocationKey, err := idemix.GenerateLongTermRevocationKey()
@@ -548,11 +475,7 @@ func TestCreateCRIGetRAInfoError(t *testing.T) {
 }
 
 func TestCreateCRIGetRevokeCredsError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "createcritest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	db := new(dmocks.FabricCADB)
 
 	revocationKey, err := idemix.GenerateLongTermRevocationKey()
@@ -567,11 +490,7 @@ func TestCreateCRIGetRevokeCredsError(t *testing.T) {
 }
 
 func TestIdemixCreateCRIError(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "createcritest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 
 	revocationKey, err := idemix.GenerateLongTermRevocationKey()
 	if err != nil {
@@ -586,11 +505,7 @@ func TestIdemixCreateCRIError(t *testing.T) {
 }
 
 func TestEpochValuesInCRI(t *testing.T) {
-	homeDir, err := ioutil.TempDir(".", "createcritest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(homeDir)
+	homeDir := t.TempDir()
 	revocationKey, err := idemix.GenerateLongTermRevocationKey()
 	if err != nil {
 		t.Fatalf("Failed to generate ECDSA key for revocation authority")

--- a/lib/server/idemix/revocationkey_test.go
+++ b/lib/server/idemix/revocationkey_test.go
@@ -27,15 +27,11 @@ const (
 )
 
 func TestLoadNonExistentRevocationPublicKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "rkloadTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 	idemixLib := new(mocks.Lib)
 	rk := NewRevocationKey(path.Join(testdir, DefaultRevocationPublicKeyFile),
 		path.Join(testdir, "msp/keystore", DefaultRevocationPrivateKeyFile), idemixLib)
-	err = rk.Load()
+	err := rk.Load()
 	assert.Error(t, err, "Should have failed to load non existent revocation public key")
 	if err != nil {
 		assert.Contains(t, err.Error(), "Failed to read revocation public key")
@@ -43,12 +39,8 @@ func TestLoadNonExistentRevocationPublicKey(t *testing.T) {
 }
 
 func TestLoadEmptyRevocationPublicKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "rkloadTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
+	testdir := t.TempDir()
 	pubkeyfile, err := ioutil.TempFile(testdir, DefaultRevocationPublicKeyFile)
-	defer os.RemoveAll(testdir)
 	idemixLib := new(mocks.Lib)
 	rk := NewRevocationKey(pubkeyfile.Name(), path.Join(testdir, "msp/keystore", DefaultRevocationPrivateKeyFile), idemixLib)
 	err = rk.Load()
@@ -59,11 +51,7 @@ func TestLoadEmptyRevocationPublicKey(t *testing.T) {
 }
 
 func TestLoadFakeRevocationPublicKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "rkloadTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 	pubkeyfile, err := ioutil.TempFile(testdir, DefaultRevocationPublicKeyFile)
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %s", err.Error())
@@ -99,11 +87,10 @@ func TestLoadFakeRevocationPublicKey(t *testing.T) {
 }
 
 func TestLoadNonExistentRevocationPrivateKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "rkloadtest")
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 	idemixLib := new(mocks.Lib)
 	rk := NewRevocationKey(testRevocationPublicKeyFile, filepath.Join(testdir, "IdemixRevocationPrivateKey"), idemixLib)
-	err = rk.Load()
+	err := rk.Load()
 	assert.Error(t, err, "Should have failed to load non existing issuer revocation private key")
 	if err != nil {
 		assert.Contains(t, err.Error(), "Failed to read revocation private key")
@@ -111,9 +98,8 @@ func TestLoadNonExistentRevocationPrivateKey(t *testing.T) {
 }
 
 func TestLoadEmptyRevocationPrivateKey(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "rkloadtest")
+	testdir := t.TempDir()
 	privkeyfile, err := ioutil.TempFile(testdir, "")
-	defer os.RemoveAll(testdir)
 	idemixLib := new(mocks.Lib)
 	rk := NewRevocationKey(testRevocationPublicKeyFile, privkeyfile.Name(), idemixLib)
 	err = rk.Load()
@@ -189,11 +175,7 @@ func TestEncodeKeys(t *testing.T) {
 }
 
 func TestStoreReadonlyRevocationPublicKeyFilepath(t *testing.T) {
-	testdir, err := ioutil.TempDir(".", "rkloadTest")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %s", err.Error())
-	}
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
 	privkeyfile, err := ioutil.TempFile(testdir, DefaultRevocationPrivateKeyFile)
 	if err != nil {

--- a/lib/server_test.go
+++ b/lib/server_test.go
@@ -105,16 +105,7 @@ func TestSRVServerInit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get cwd: %s", err)
 	}
-	td, err := ioutil.TempDir("", "ServerInitStat")
-	if err != nil {
-		t.Fatalf("failed to get tmp dir: %s", err)
-	}
-	defer func() {
-		err = os.RemoveAll(td)
-		if err != nil {
-			t.Fatalf("RemoveAll failed: %s", err)
-		}
-	}()
+	td := t.TempDir()
 	server.HomeDir = ""
 	err = os.Chdir(td)
 	if err != nil {

--- a/lib/servercertificates_test.go
+++ b/lib/servercertificates_test.go
@@ -262,12 +262,10 @@ func TestServerGetCertificates(t *testing.T) {
 }
 
 func TestStoreCert(t *testing.T) {
-	dir, err := ioutil.TempDir("", "testStoreCert")
-	assert.NoError(t, err, "failed to create temp directory")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	cd := NewCertificateDecoder(dir)
-	err = cd.storeCert("testID", dir, []byte("testing store cert function"))
+	err := cd.storeCert("testID", dir, []byte("testing store cert function"))
 	assert.NoError(t, err, "failed to store cert")
 
 	filePath := filepath.Join(dir, "testID.pem")

--- a/util/configurebccsp_test.go
+++ b/util/configurebccsp_test.go
@@ -10,8 +10,6 @@ SPDX-License-Identifier: Apache-2.0
 package util
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/hyperledger/fabric/bccsp/factory"
@@ -20,9 +18,7 @@ import (
 )
 
 func TestConfigureBCCSP(t *testing.T) {
-	mspDir, err := ioutil.TempDir("", "util-bccsp")
-	assert.NoError(t, err)
-	defer os.RemoveAll(mspDir)
+	mspDir := t.TempDir()
 
 	lib, pin, label := pkcs11.FindPKCS11Lib()
 	opts := &factory.FactoryOpts{
@@ -36,7 +32,7 @@ func TestConfigureBCCSP(t *testing.T) {
 		},
 	}
 
-	err = ConfigureBCCSP(&opts, mspDir, "")
+	err := ConfigureBCCSP(&opts, mspDir, "")
 	assert.NoError(t, err, "bccsp initialization failed")
 }
 

--- a/util/csp_test.go
+++ b/util/csp_test.go
@@ -53,12 +53,10 @@ func testMain(m *testing.M) int {
 }
 
 func TestInitBCCSP(t *testing.T) {
-	mspDir, err := ioutil.TempDir("", "util-bccsp-msp")
-	assert.NoError(t, err)
-	defer os.RemoveAll(mspDir)
+	mspDir := t.TempDir()
 
 	var opts *factory.FactoryOpts
-	_, err = InitBCCSP(&opts, "", mspDir)
+	_, err := InitBCCSP(&opts, "", mspDir)
 	assert.NoError(t, err, "first initialization of BCCSP failed")
 
 	cfg := &factory.FactoryOpts{ProviderName: "SW"}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -203,9 +203,7 @@ func TestRandomString(t *testing.T) {
 }
 
 func TestCreateHome(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "test")
-	assert.NoError(t, err, "failed to create temporary directory")
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	os.Setenv("HOME", tempDir)
 	dir, err := CreateClientHome()
@@ -286,12 +284,10 @@ func TestReadFile(t *testing.T) {
 }
 
 func TestWriteFile(t *testing.T) {
-	testdir, err := ioutil.TempDir("", "writefiletest")
-	assert.NoError(t, err)
-	defer os.RemoveAll(testdir)
+	testdir := t.TempDir()
 
 	testData := []byte("foo")
-	err = WriteFile(filepath.Join(testdir, "test.txt"), testData, 0777)
+	err := WriteFile(filepath.Join(testdir, "test.txt"), testData, 0777)
 	assert.NoError(t, err)
 
 	readOnlyDir := filepath.Join(testdir, "readonlydir")


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

#### Additional details

#### Related issues
