### PR TITLE
Make the debug flag visible in --help and docs

### DIFF
--- a/docs/source/servercli.rst
+++ b/docs/source/servercli.rst
@@ -38,6 +38,7 @@ Fabric-CA Server's CLI
           --csr.keyrequest.reusekey                   Reuse existing key during reenrollment
           --csr.keyrequest.size int                   Specify key size
           --csr.serialnumber string                   The serial number in a certificate signing request to a parent fabric-ca-server
+      -d, --debug bool                                Enable debug level logging (slows server) (default false)
           --db.datasource string                      Data source which is database specific (default "fabric-ca-server.db")
           --db.tls.certfiles strings                  A list of comma-separated PEM-encoded trusted certificate files (e.g. root1.pem,root2.pem)
           --db.tls.client.certfile string             PEM-encoded certificate file when mutual authenticate is enabled

--- a/lib/serverconfig.go
+++ b/lib/serverconfig.go
@@ -34,7 +34,7 @@ type ServerConfig struct {
 	// Cross-Origin Resource Sharing settings for the server
 	CORS CORS
 	// Enables debug logging
-	Debug bool `def:"false" opt:"d" help:"Enable debug level logging" hide:"true"`
+	Debug bool `def:"false" opt:"d" help:"Enable debug level logging (slows server)"`
 	// Sets the logging level on the server
 	LogLevel string `help:"Set logging level (info, warning, debug, error, fatal, critical)"`
 	// TLS for the server's listening endpoint


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

The `-d` flag is used by default in test/demo materials such as hyperledger/fabric-samples, so having the the flag be hidden from the documentation causes confusion. Remove 'hide'; add a warning for why users might not want to use it, since those drawbacks were probably the primary reason it was hidden before.