### PR TITLE
escape special charecters that can be set through the command line ar…

### DIFF
--- a/cmd/fabric-ca-server/config.go
+++ b/cmd/fabric-ca-server/config.go
@@ -68,7 +68,7 @@ const (
 #############################################################################
 
 # Version of config file
-version: <<<VERSION>>>
+version: "<<<VERSION>>>"
 
 # Server's listening port (default: 7054)
 port: 7054
@@ -159,8 +159,8 @@ registry:
 
   # Contains identity information which is used when LDAP is disabled
   identities:
-     - name: <<<ADMIN>>>
-       pass: <<<ADMINPW>>>
+     - name: "<<<ADMIN>>>"
+       pass: "<<<ADMINPW>>>"
        type: client
        affiliation: ""
        attrs:
@@ -339,7 +339,7 @@ signing:
 #  if the server creates a self-signed TLS certificate.
 ###########################################################################
 csr:
-   cn: <<<COMMONNAME>>>
+   cn: "<<<COMMONNAME>>>"
    keyrequest:
      algo: ecdsa
      size: 256
@@ -350,11 +350,11 @@ csr:
         O: Hyperledger
         OU: Fabric
    hosts:
-     - <<<MYHOST>>>
+     - "<<<MYHOST>>>"
      - localhost
    ca:
       expiry: 131400h
-      pathlength: <<<PATHLENGTH>>>
+      pathlength: "<<<PATHLENGTH>>>"
 
 ###########################################################################
 # Each CA can issue both X509 enrollment certificate as well as Idemix


### PR DESCRIPTION
…guments

Signed-off-by: Rohan Shrothrium <rohan.shrothrium@intellecteu.com>

#### Type of change

- Bug fix

#### Description

When we initialise a fabric ca server with an admin and adminpw, if they have special characters the ca behaves not as expected.
These special characters can be in anything that can be passed through the command line arguments.
This PR is meant to escape these special characters in the `yml` file.

