### PR TITLE
Bump Alpine to 3.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@
 #   - vendor - vendors third-party packages
 
 PROJECT_NAME = fabric-ca
-ALPINE_VER ?= 3.14
+ALPINE_VER ?= 3.16
 DEBIAN_VER ?= stretch
 BASE_VERSION = 1.5.4
 IS_RELEASE = false


### PR DESCRIPTION
Bump Alpine to 3.16.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>