### PR TITLE
Add commit hash to Github Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,15 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: 'Fabric CA Release'
+        description: 'Fabric CA Release, e.g. 1.5.5'
         required: true
         type: string
       two_digit_release:
-        description: 'Fabric CA Two Digit Release'
+        description: 'Fabric CA Two Digit Release, e.g. 1.5'
+        required: true
+        type: string
+      commit_hash:
+        description: 'Commit hash, e.g. df9c661a192f8cf11376d9d643a0021f1a76c34b'
         required: true
         type: string
 
@@ -88,5 +92,6 @@ jobs:
         with:
           artifacts: "*.tar.gz/*.tar.gz"
           bodyFile: release_notes/v${{ inputs.release }}.md
+          commit: ${{ inputs.commit_hash }}
           tag: v${{ inputs.release }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The commit hash is needed to properly tag the correct release branch release commit.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>
