### PR TITLE
 Build multi-arch docker images with buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,24 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Release
+
 on:
-  workflow_dispatch:
-    inputs:
-      release:
-        description: 'Fabric CA Release, e.g. 1.5.6'
-        required: true
-        type: string
-      two_digit_release:
-        description: 'Fabric CA Two Digit Release, e.g. 1.5'
-        required: true
-        type: string
-      commit_hash:
-        description: 'Commit hash, e.g. df9c661a192f8cf11376d9d643a0021f1a76c34b'
-        required: true
-        type: string
+  push:
+    tags: [ v* ]
 
 env:
   GO_VER: 1.18.8
+  ALPINE_VER: 3.17
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 permissions:
   contents: read
@@ -31,63 +23,104 @@ jobs:
     strategy:
       matrix:
         include:
-        - image: ubuntu-20.04
-          platform: linux-amd64
-        - image: ubuntu-20.04
-          platform: linux-arm64
-        - image: macos-12
-          platform: darwin-arm64
-        - image: macos-12
-          platform: darwin-amd64
-        - image: windows-2022
-          platform: windows-amd64
-
+          - image: ubuntu-20.04
+            platform: linux-amd64
+          - image: ubuntu-20.04
+            platform: linux-arm64
+          - image: macos-12
+            platform: darwin-arm64
+          - image: macos-12
+            platform: darwin-amd64
+          - image: windows-2022
+            platform: windows-amd64
     runs-on: ${{ matrix.image }}
     steps:
       - uses: actions/setup-go@v3
         name: Install Go
         with:
           go-version: ${{ env.GO_VER }}
+
       - uses: actions/checkout@v3
         name: Checkout Fabric CA Code
-      - name: Install linux aarch64 compiler
-        run: sudo apt-get -y install gcc-aarch64-linux-gnu
+
+      - name: Install GCC cross-compilers
         if:  ${{ contains(matrix.platform, 'linux') }}
+        run: |
+          sudo apt-get -y install gcc-aarch64-linux-gnu
+          sudo apt-get -y install gcc-x86-64-linux-gnu
+
       - run: make dist/${{ matrix.platform }}
         name: Compile Binary and Create Tarball
+        env:
+          BASE_VERSION: ${{ github.ref_name }}
+
       - uses: actions/upload-artifact@v3
         name: Publish Release Artifact
         with:
-          name: hyperledger-fabric-ca-${{ matrix.platform }}-${{ inputs.release }}.tar.gz
-          path: release/${{ matrix.platform }}/hyperledger-fabric-ca-${{ matrix.platform }}-${{ inputs.release }}.tar.gz
+          name: hyperledger-fabric-ca-${{ matrix.platform }}-${{ github.ref_name }}.tar.gz
+          path: release/${{ matrix.platform }}/hyperledger-fabric-ca-${{ matrix.platform }}-${{ github.ref_name }}.tar.gz
 
-  build-and-push-docker-images:
-    name: Build and Push Fabric CA Docker Images
+  build-and-push-image:
     runs-on: ubuntu-20.04
+
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - run: sudo apt clean
-        name: Run APT Clean
-      - run: sudo apt update
-        name: Run Apt Update
-      - run: sudo apt install -y gcc haveged libtool make
-        name: Install Dependencies
-      - uses: actions/setup-go@v3
-        name: Install Go
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Login to the GitHub Container Registry
+        uses: docker/login-action@v2
         with:
-          go-version: ${{ env.GO_VER }}
-      - uses: actions/checkout@v3
-        name: Checkout Fabric CA Code
-      - run: ./ci/scripts/publish_docker.sh
-        env:
-          RELEASE: ${{ inputs.release }}
-          TWO_DIGIT_RELEASE: ${{ inputs.two_digit_release }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        name: Publish Docker Images
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      #      - name: Login to Docker Hub Container Registry
+      #        uses: docker/login-action@v2
+      #        with:
+      #          registry: docker.io
+      #          username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}.{{minor}}.{{patch}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: images/fabric-ca/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          push: ${{ github.event_name != 'pull_request' }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ALPINE_VER=${{ env.ALPINE_VER }}
+            GO_VER=${{ env.GO_VER }}
+            GO_TAGS=pkcs11
+            GO_LDFLAGS=-X github.com/hyperledger/fabric-ca/lib/metadata.Version=${{ github.ref_name }} -linkmode external -extldflags '-lpthread -static'
+
 
   create-release:
     name: Create GitHub Release
-    needs: [ build-binaries, build-and-push-docker-images ]
+    needs: [ build-binaries, build-and-push-image ]
     runs-on: ubuntu-20.04
     permissions:
       contents: write
@@ -100,8 +133,8 @@ jobs:
       - name: Release Fabric CA Version
         uses: ncipollo/release-action@v1
         with:
+          allowUpdates: "true"
           artifacts: "*.tar.gz/*.tar.gz"
-          bodyFile: release_notes/v${{ inputs.release }}.md
-          commit: ${{ inputs.commit_hash }}
-          tag: v${{ inputs.release }}
+          bodyFile: release_notes/${{ github.ref_name }}.md
+          tag: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/metadata/version.go
+++ b/lib/metadata/version.go
@@ -101,8 +101,14 @@ func GetLevels(version string) (*db.Levels, error) {
 }
 
 // CmpVersion compares version v1 to v2.
+// Strips off an optional 'v' prefix for semrev tags
 // Return 0 if equal, 1 if v2 > v1, or -1 if v2 < v1.
 func CmpVersion(v1, v2 string) (int, error) {
+
+	// optionally remove the semrev 'v', if present
+	v1 = strings.TrimPrefix(v1, "v")
+	v2 = strings.TrimPrefix(v2, "v")
+
 	v1strs := strs(v1)
 	v2strs := strs(v2)
 	m := max(len(v1strs), len(v2strs))

--- a/lib/metadata/version_test.go
+++ b/lib/metadata/version_test.go
@@ -32,11 +32,28 @@ func TestVersion(t *testing.T) {
 	cmpVersion(t, "1.0.0", "1.0.0.1", 1)
 	cmpVersion(t, "1.1.0", "1.0.0", -1)
 	cmpVersion(t, "1.0.0.0.1", "1.0", -1)
+
+	cmpVersion(t, "v1.2.3", "v1.2.3", 0)
+	cmpVersion(t, "v1.2.3", "1.2.3", 0)
+	cmpVersion(t, "1.2.3", "v1.2.3", 0)
+
+	cmpVersion(t, "v1.2.3", "1.0", -1)
+	cmpVersion(t, "v1.2.3", "1.1", -1)
+	cmpVersion(t, "v1.2.3", "1.2", -1)
+	cmpVersion(t, "v1.2.3", "1.3", 1)
+
 	cmpLevels(t, "1.0.0", 0, 0, 0)
 	cmpLevels(t, "1.0.4", 0, 0, 0)
 	cmpLevels(t, "1.1.0", 1, 1, 1)
 	cmpLevels(t, "1.1.1", 1, 1, 1)
 	cmpLevels(t, "1.2.1", 1, 1, 1)
+
+	cmpLevels(t, "v1.0.0", 0, 0, 0)
+	cmpLevels(t, "v1.0.4", 0, 0, 0)
+	cmpLevels(t, "v1.1.0", 1, 1, 1)
+	cmpLevels(t, "v1.1.1", 1, 1, 1)
+	cmpLevels(t, "v1.2.1", 1, 1, 1)
+
 	// Negative test cases
 	_, err := metadata.CmpVersion("1.x.2.0", "1.7.8")
 	if err == nil {

--- a/release_notes/v1.5.6-beta.md
+++ b/release_notes/v1.5.6-beta.md
@@ -1,16 +1,17 @@
 v1.5.6 Release Notes - July 8, 2022
 ===================================
 
-v1.5.6 is a maintenance release, providing updates for the following issues in the Fabric CA:
+v1.5.6-beta is a beta release, providing updates for the following issues in the Fabric CA:
 
 - Builds native arm64 CA binaries for linux and darwin
+- Builds multi-platform CA docker images for arm64 and amd64 with `buildx`
 
 Dependencies
 ------------
 
 Fabric CA v1.5.6 has been tested with the following dependencies:
 - Go 1.18.8
-- Alpine 3.16 (for Docker images)
+- Alpine 3.17 (for Docker images)
 
 Changes, Known Issues, and Workarounds
 --------------------------------------


### PR DESCRIPTION
This PR is configured to publish docker images to ghcr.io/hyperledger/fabric-ca. 

This will allow us to test the mechanics of building, publishing, etc. on a repo other than docker.io prior to the formal 1.5.6 release.

To trigger the release action, draft a new GH Release, applying a semrev tag (e.g. `v1.5.6-beta`) to a target branch. 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change

- New feature


#### Description

This PR adds support for multi-arch Docker images, generated with the buildx builder.

This PR also modifies the CA binaries to include the `{{ github.ref_name }}` directly when compiling the routine metadata.  This allows for a semantic revision (e.g. `v1.2.3`, `v1.2.3-alpha`, etc.) strings to be specified as valid version identifiers for the binaries. 

#### Additional details

The main challenge with this PR was not the addition of the GHA pipeline to run with buildx, but the dependency on CGO for the platform-specific compilation of sqlite C code.  What unlocked this feature was to break up the "build" into two separate routes: 

- for client binaries, generate a CGO=1 compiled binary, using a GCC cross-compiler to target a specific architecture.
- for Docker images, use Docker `buildx` to emulate an architecture with QEMU, building with sqlite with GCC.

Unfortunately the fabric-ca-fvt images could not be ported over to an arm64 runtime, as there are several dependencies installed to the test image that do not include native support for arm64. When running the fvt tests, the container can be launched on an amd64 machine or under emulation with QEMU.

I tried to clean up the Makefile with this PR, but triggered a never-ending snowball effect that ended up wedging the FVT tests beyond repair.  There may be some lingering dependencies between unit test outputs that have been mounted accidentally and used as inputs to the FVT container volume mounts.

There may still be some lingering rough edges around statically linking the sqlite objects into golang with glibc, which is not technically supported on alpine.

#### Related issues

* [Native Support For 64bit ARM in fabric fabric#2994 (comment)](https://github.com/hyperledger/fabric/issues/2994#issuecomment-1170102505)