### PR TITLE
Publish release artifacts to conventional installation paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ name: Release
 
 on:
   push:
-    tags: [ v* ]
+    tags: [ v1.* ]
 
 env:
   GO_VER: 1.18.8
@@ -46,6 +46,7 @@ jobs:
       - name: Install GCC cross-compilers
         if:  ${{ contains(matrix.platform, 'linux') }}
         run: |
+          sudo apt-get update
           sudo apt-get -y install gcc-aarch64-linux-gnu
           sudo apt-get -y install gcc-x86-64-linux-gnu
 
@@ -55,10 +56,13 @@ jobs:
           BASE_VERSION: ${{ github.ref_name }}
 
       - uses: actions/upload-artifact@v3
-        name: Publish Release Artifact
+        name: Publish Release Artifacts
         with:
-          name: hyperledger-fabric-ca-${{ matrix.platform }}-${{ github.ref_name }}.tar.gz
-          path: release/${{ matrix.platform }}/hyperledger-fabric-ca-${{ matrix.platform }}-${{ github.ref_name }}.tar.gz
+          # <name> of the artifact must not collide between platform/arch builds
+          name: release-${{ matrix.platform }}
+          # <path> of the artifact may include multiple files.
+          path: release/${{ matrix.platform }}/*.tar.gz
+
 
   build-and-push-image:
     runs-on: ubuntu-20.04
@@ -77,13 +81,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      #      - name: Login to Docker Hub Container Registry
-      #        uses: docker/login-action@v2
-      #        with:
-      #          registry: docker.io
-      #          username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#          registry: docker.io
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
@@ -120,7 +120,9 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [ build-binaries, build-and-push-image ]
+    needs:
+      - build-binaries
+      - build-and-push-image
     runs-on: ubuntu-20.04
     permissions:
       contents: write
@@ -134,7 +136,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: "true"
-          artifacts: "*.tar.gz/*.tar.gz"
+          artifacts: "release-*-*/*.tar.gz"
           bodyFile: release_notes/${{ github.ref_name }}.md
           tag: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -33,23 +33,19 @@ GO_VER = 1.18.8
 ALPINE_VER ?= 3.17
 DEBIAN_VER ?= stretch
 BASE_VERSION ?= v1.5.6
-IS_RELEASE = true
 
 ARCH=$(shell go env GOARCH)
 PLATFORM=$(shell go env GOOS)-$(shell go env GOARCH)
 
-ifneq ($(IS_RELEASE),true)
-EXTRA_VERSION ?= snapshot-$(shell git rev-parse --short HEAD)
-PROJECT_VERSION=$(BASE_VERSION)-$(EXTRA_VERSION)
-else
-PROJECT_VERSION=$(BASE_VERSION)
-endif
+# For compatibility with legacy install-fabric.sh conventions, strip the
+# leading semrev 'v' character when preparing dist and release artifacts.
+RELEASE_VERSION=$(shell echo $(BASE_VERSION) | sed -e  's/^v\(.*\)/\1/')
 
 PG_VER=11
 
 PKGNAME = github.com/hyperledger/$(PROJECT_NAME)
 
-METADATA_VAR = Version=$(PROJECT_VERSION)
+METADATA_VAR = Version=$(BASE_VERSION)
 
 GO_SOURCE := $(shell find . -name '*.go')
 GO_LDFLAGS = $(patsubst %,-X $(PKGNAME)/lib/metadata.%,$(METADATA_VAR))
@@ -209,11 +205,11 @@ docker-thirdparty:
 
 .PHONY: dist
 dist: dist-clean release
-	cd release/$(PLATFORM) && tar -czvf hyperledger-fabric-ca-$(PLATFORM)-$(PROJECT_VERSION).tar.gz *
+	cd release/$(PLATFORM) && tar -czvf hyperledger-fabric-ca-$(PLATFORM)-$(RELEASE_VERSION).tar.gz *
 
 dist/%: release/%
 	$(eval PLATFORM = ${patsubst dist/%,%,${@}})
-	cd release/$(PLATFORM) && tar -czvf hyperledger-fabric-ca-$(PLATFORM)-$(PROJECT_VERSION).tar.gz *
+	cd release/$(PLATFORM) && tar -czvf hyperledger-fabric-ca-$(PLATFORM)-$(RELEASE_VERSION).tar.gz *
 
 .PHONY: clean
 clean: docker-clean release-clean
@@ -229,10 +225,10 @@ release-clean: $(patsubst %,%-release-clean, $(RELEASE_PLATFORMS))
 
 .PHONY: dist-clean
 dist-clean:
-	-@rm -rf release/windows-amd64/hyperledger-fabric-ca-windows-amd64-$(PROJECT_VERSION).tar.gz ||:
-	-@rm -rf release/darwin-amd64/hyperledger-fabric-ca-darwin-amd64-$(PROJECT_VERSION).tar.gz ||:
-	-@rm -rf release/linux-amd64/hyperledger-fabric-ca-linux-amd64-$(PROJECT_VERSION).tar.gz ||:
-	-@rm -rf release/darwin-arm64/hyperledger-fabric-ca-darwin-arm64-$(PROJECT_VERSION).tar.gz ||:
-	-@rm -rf release/linux-arm64/hyperledger-fabric-ca-linux-arm64-$(PROJECT_VERSION).tar.gz ||:
+	-@rm -rf release/windows-amd64/hyperledger-fabric-ca-windows-amd64-$(RELEASE_VERSION).tar.gz ||:
+	-@rm -rf release/darwin-amd64/hyperledger-fabric-ca-darwin-amd64-$(RELEASE_VERSION).tar.gz ||:
+	-@rm -rf release/linux-amd64/hyperledger-fabric-ca-linux-amd64-$(RELEASE_VERSION).tar.gz ||:
+	-@rm -rf release/darwin-arm64/hyperledger-fabric-ca-darwin-arm64-$(RELEASE_VERSION).tar.gz ||:
+	-@rm -rf release/linux-arm64/hyperledger-fabric-ca-linux-arm64-$(RELEASE_VERSION).tar.gz ||:
 
 .FORCE:

--- a/release_notes/v1.5.6-beta.md
+++ b/release_notes/v1.5.6-beta.md
@@ -1,4 +1,4 @@
-v1.5.6 Release Notes - July 8, 2022
+v1.5.6-beta Release Notes - Dec 9, 2022
 ===================================
 
 v1.5.6-beta is a beta release, providing updates for the following issues in the Fabric CA:


### PR DESCRIPTION
Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change

- Bug fix

#### Description

This PR publishes the v1.5.6-beta release artifacts to GH as artifacts, stripping the semrev 'v' character for alignment with the traditional install-fabric.sh scripts. 

#### Additional details

#### Related issues

#### Release Note
