### PR TITLE
[Documentation update]Update configtx.rst

### DIFF
--- a/docs/source/configtx.rst
+++ b/docs/source/configtx.rst
@@ -35,7 +35,7 @@
          # for cross org gossip communication.  Note, this value is only
          # encoded in the genesis block in the Application section context
          - Host: peer1-org1
-            Port: 7051
+           Port: 7051
 
    - &org2
 
@@ -52,7 +52,7 @@
          # for cross org gossip communication.  Note, this value is only
          # encoded in the genesis block in the Application section context
          - Host: peer1-org2
-            Port: 7051
+           Port: 7051
 
    ################################################################################
    #
@@ -79,56 +79,55 @@
    ################################################################################
    Profiles:
 
-   OrgsOrdererGenesis:
-      Orderer:
-         # Orderer Type: The orderer implementation to start
-         # Available types are "solo" and "kafka"
-         OrdererType: solo
-         Addresses:
-         - orderer1-org0:7050
+     OrgsOrdererGenesis:
+       Orderer:
+           # Orderer Type: The orderer implementation to start
+           # Available types are "solo" and "kafka"
+           OrdererType: solo
+           Addresses:
+             - orderer1-org0:7050
 
-         # Batch Timeout: The amount of time to wait before creating a batch
-         BatchTimeout: 2s
+           # Batch Timeout: The amount of time to wait before creating a batch
+           BatchTimeout: 2s
 
-         # Batch Size: Controls the number of messages batched into a block
-         BatchSize:
+           # Batch Size: Controls the number of messages batched into a block
+           BatchSize:
 
-         # Max Message Count: The maximum number of messages to permit in a batch
-         MaxMessageCount: 10
+             # Max Message Count: The maximum number of messages to permit in a batch
+             MaxMessageCount: 10
 
-         # Absolute Max Bytes: The absolute maximum number of bytes allowed for
-         # the serialized messages in a batch.
-         AbsoluteMaxBytes: 99 MB
+             # Absolute Max Bytes: The absolute maximum number of bytes allowed for
+             # the serialized messages in a batch.
+             AbsoluteMaxBytes: 99 MB
 
-         # Preferred Max Bytes: The preferred maximum number of bytes allowed for
-         # the serialized messages in a batch. A message larger than the preferred
-         # max bytes will result in a batch larger than preferred max bytes.
-         PreferredMaxBytes: 512 KB
+             # Preferred Max Bytes: The preferred maximum number of bytes allowed for
+             # the serialized messages in a batch. A message larger than the preferred
+             # max bytes will result in a batch larger than preferred max bytes.
+             PreferredMaxBytes: 512 KB
 
-         # Kafka:
-         #   # Brokers: A list of Kafka brokers to which the orderer connects
-         #   # NOTE: Use IP:port notation
-         #   Brokers:
-         #     - 127.0.0.1:9092
+           # Kafka:
+           #   # Brokers: A list of Kafka brokers to which the orderer connects
+           #   # NOTE: Use IP:port notation
+           #   Brokers:
+           #     - 127.0.0.1:9092
 
-         # Organizations is the list of orgs which are defined as participants on
-         # the orderer side of the network
-         Organizations:
-         - *org0
+           # Organizations is the list of orgs which are defined as participants on
+           # the orderer side of the network
+           Organizations:
+             - *org0
 
-      Consortiums:
+       Consortiums:
 
          SampleConsortium:
 
-         Organizations:
-            - *org1
-            - *org2
+           Organizations:
+             - *org1
+             - *org2
 
-   OrgsChannel:
-      Consortium: SampleConsortium
-      Application:
-         <<: *ApplicationDefaults
-         Organizations:
-         - *org1
-         - *org2
-
+     OrgsChannel:
+       Consortium: SampleConsortium
+       Application:
+           <<: *ApplicationDefaults
+           Organizations:
+             - *org1
+             - *org2

--- a/docs/source/docker_compose.rst
+++ b/docs/source/docker_compose.rst
@@ -174,6 +174,7 @@
          - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer2-org2:7051
          - CORE_PEER_GOSSIP_SKIPHANDSHAKE=true
          - CORE_PEER_GOSSIP_BOOTSTRAP=peer1-org2:7051
+         - GODEBUG=netdns=go
       working_dir: /opt/gopath/src/github.com/hyperledger/fabric/org2/peer2
       volumes:
          - /var/run:/host/var/run

--- a/docs/source/docker_compose.rst
+++ b/docs/source/docker_compose.rst
@@ -120,6 +120,7 @@
          - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer2-org1:7051
          - CORE_PEER_GOSSIP_SKIPHANDSHAKE=true
          - CORE_PEER_GOSSIP_BOOTSTRAP=peer1-org1:7051
+         - GODEBUG=netdns=go
       working_dir: /opt/gopath/src/github.com/hyperledger/fabric/org1/peer2
       volumes:
          - /var/run:/host/var/run


### PR DESCRIPTION
fix following issue after run `configtxgen -profile OrgsOrdererGenesis -outputBlock /tmp/hyperledger/org0/orderer/genesis.block -channelID syschannel` by fix format.
* 'Organizations[0]' has invalid keys: OrdererEndpoints
* 'Profiles[TwoOrgsOrdererGenesis].Orderer.Organizations[0]' has invalid keys: OrdererEndpoints
* Profiles[TwoOrgsOrdererGenesis].Orderer.Organizations[0]' has invalid keys: OrdererEndpoints [recovered]
* 'Profiles[TwoOrgsOrdererGenesis].Orderer.Organizations[0]' has invalid keys: OrdererEndpoints
* Error reading configuration: While parsing config: yaml: line 85: mapping values are not allowed in this context
* '' has invalid keys: orgschannel, orgsorderergenesis
* 'Profiles[OrgsOrdererGenesis].Consortiums[Organizations]' expected a map, got 'slice'

Signed-off-by: LF <xiayanzheng@outlook.com>

<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Documentation update

#### Description

<!--- Describe your changes in detail, including motivation. -->

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

#### Related issues

<!--- Include a link to any associated issues, e.g. Jira issue or approved rfc. -->

<!---
#### Release Note
If change impacts current users, uncomment Release Note heading and provide
release note text.
-->

<!--
Checklist (DELETE AFTER READING):

- `Signed-off-by` added to commits (required for DCO check to pass)
- Tests have been added/updated (required for bug fixes and features)
- Unit and/or integration tests pass locally
- Run linters and checks locally using 'make checks'
- If change requires documentation updates, make updates in pull request,
  or open a separate issue and provide link
- Squash commits into a single commit, unless a stack of commits is
  intentional to assist reviewers or to preserve review comments.
- For additional contribution guidelines see the project's CONTRIBUTING.md file
-->
