### PR TITLE
Publishes release images to the docker.io, not ghcr.io container registry.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 env:
   GO_VER: 1.18.8
   ALPINE_VER: 3.17
-  REGISTRY: ghcr.io
+  REGISTRY: docker.io    # or ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 permissions:
@@ -75,15 +75,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Login to the GitHub Container Registry
+      - name: Login to the ${{ env.REGISTRY }} Container Registry
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-#          registry: docker.io
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ contains(env.REGISTRY, 'docker.io') && secrets.DOCKERHUB_USERNAME || github.actor }}
+          password: ${{ contains(env.REGISTRY, 'docker.io') && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
#### Type of change

- CI pipeline

#### Description

This PR changes the target container registry from ghcr.io to docker.io. 
