### PR TITLE
Adds v1.5.6-beta2 release notes

### DIFF
--- a/release_notes/v1.5.6-beta2.md
+++ b/release_notes/v1.5.6-beta2.md
@@ -1,0 +1,46 @@
+v1.5.6-beta2 Release Notes - Dec 15, 2022
+===================================
+
+v1.5.6-beta2 is a beta release, providing updates for the following issues in the Fabric CA:
+
+- Builds native arm64 CA binaries for linux and darwin
+- Builds multi-platform CA docker images for arm64 and amd64 with `buildx`
+- Adds debug information for a mysterious [idemix error message](https://github.com/hyperledger/fabric-ca/pull/339)
+
+
+Dependencies
+------------
+
+Fabric CA v1.5.6 has been tested with the following dependencies:
+- Go 1.18.8
+- Alpine 3.17 (for Docker images)
+
+Changes, Known Issues, and Workarounds
+--------------------------------------
+
+None.
+
+Known Vulnerabilities
+---------------------
+- FABC-174 Commands can be manipulated to delete identities or affiliations
+
+  This vulnerability can be resolved in one of two ways:
+
+    1) Use HTTPS (TLS) so that the authorization header is not in clear text.
+
+    2) The token generation/authentication mechanism was improved to optionally prevent
+       token reuse. As of v1.4 a more secure token can be used by setting environment variable:
+
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false
+
+  However, it cannot be set to false until all clients have
+  been updated to generate the more secure token and tolerate
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false.
+  The Fabric CA client has been updated in v1.4 to generate the more secure token.
+  The Fabric SDKs will be updated by v2.0 timeframe to generate the more secure token,
+  at which time the default for Fabric CA server will change to:
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false
+
+Resolved Vulnerabilities
+------------------------
+None.


### PR DESCRIPTION
Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Release Note

v1.5.6-beta2 Release Notes - Dec 15, 2022
===================================

v1.5.6-beta2 is a beta release, providing updates for the following issues in the Fabric CA:

- Builds native arm64 CA binaries for linux and darwin
- Builds multi-platform CA docker images for arm64 and amd64 with `buildx`
- Adds debug information for a mysterious [idemix error message](https://github.com/hyperledger/fabric-ca/pull/339)


Dependencies
------------

Fabric CA v1.5.6 has been tested with the following dependencies:
- Go 1.18.8
- Alpine 3.17 (for Docker images)

Changes, Known Issues, and Workarounds
--------------------------------------

None.

Known Vulnerabilities
---------------------
- FABC-174 Commands can be manipulated to delete identities or affiliations

  This vulnerability can be resolved in one of two ways:

    1) Use HTTPS (TLS) so that the authorization header is not in clear text.

    2) The token generation/authentication mechanism was improved to optionally prevent
       token reuse. As of v1.4 a more secure token can be used by setting environment variable:

  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false

  However, it cannot be set to false until all clients have
  been updated to generate the more secure token and tolerate
  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false.
  The Fabric CA client has been updated in v1.4 to generate the more secure token.
  The Fabric SDKs will be updated by v2.0 timeframe to generate the more secure token,
  at which time the default for Fabric CA server will change to:
  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false

Resolved Vulnerabilities
------------------------
None.

