### PR TITLE
Switch base docker images from alpine to ubuntu:20.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ on:
     tags: [ v1.* ]
 
 env:
-  GO_VER: 1.18.8
-  ALPINE_VER: 3.17
-  REGISTRY: docker.io    # or ghcr.io
+  GO_VER: 1.18.9
+  UBUNTU_VER: 20.04
+  DOCKER_REGISTRY: ${{ github.repository_owner == 'hyperledger' && 'docker.io' || 'ghcr.io' }}
   IMAGE_NAME: ${{ github.repository }}
 
 permissions:
@@ -75,18 +75,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Login to the ${{ env.REGISTRY }} Container Registry
+      - name: Login to the ${{ env.DOCKER_REGISTRY }} Container Registry
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ contains(env.REGISTRY, 'docker.io') && secrets.DOCKERHUB_USERNAME || github.actor }}
-          password: ${{ contains(env.REGISTRY, 'docker.io') && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ env.DOCKER_REGISTRY == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
+          password: ${{ env.DOCKER_REGISTRY == 'docker.io' && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.DOCKER_REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -109,10 +109,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            ALPINE_VER=${{ env.ALPINE_VER }}
+            UBUNTU_VER=${{ env.UBUNTU_VER }}
             GO_VER=${{ env.GO_VER }}
             GO_TAGS=pkcs11
-            GO_LDFLAGS=-X github.com/hyperledger/fabric-ca/lib/metadata.Version=${{ github.ref_name }} -linkmode external -extldflags '-lpthread -static'
+            GO_LDFLAGS=-X github.com/hyperledger/fabric-ca/lib/metadata.Version=${{ github.ref_name }}
 
 
   create-release:

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@
 
 PROJECT_NAME = fabric-ca
 
-GO_VER = 1.18.8
-ALPINE_VER ?= 3.17
+GO_VER = 1.18.9
+UBUNTU_VER ?= 20.04
 DEBIAN_VER ?= stretch
 BASE_VERSION ?= v1.5.6
 
@@ -40,6 +40,7 @@ PLATFORM=$(shell go env GOOS)-$(shell go env GOARCH)
 # For compatibility with legacy install-fabric.sh conventions, strip the
 # leading semrev 'v' character when preparing dist and release artifacts.
 RELEASE_VERSION=$(shell echo $(BASE_VERSION) | sed -e  's/^v\(.*\)/\1/')
+PROJECT_VERSION=${RELEASE_VERSION}
 
 PG_VER=11
 
@@ -108,9 +109,9 @@ build/image/fabric-ca/$(DUMMY):
 		--build-arg GO_VER=${GO_VER} \
 		--build-arg GO_TAGS=pkcs11 \
 		--build-arg GO_LDFLAGS="${DOCKER_GO_LDFLAGS}" \
-		--build-arg ALPINE_VER=${ALPINE_VER} \
+		--build-arg UBUNTU_VER=${UBUNTU_VER} \
 		-t $(DOCKER_NS)/$(TARGET) .
-	docker tag $(DOCKER_NS)/$(TARGET) $(DOCKER_NS)/$(TARGET):$(BASE_VERSION)
+	docker tag $(DOCKER_NS)/$(TARGET) $(DOCKER_NS)/$(TARGET):$(PROJECT_VERSION)
 	docker tag $(DOCKER_NS)/$(TARGET) $(DOCKER_NS)/$(TARGET):$(DOCKER_TAG)
 	@touch $@
 

--- a/images/fabric-ca/Dockerfile
+++ b/images/fabric-ca/Dockerfile
@@ -3,31 +3,58 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-ARG GO_VER
-ARG ALPINE_VER
 
-FROM golang:${GO_VER}-alpine as builder
+###############################################################################
+# Build image
+###############################################################################
+
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER} as builder
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG GO_VER
 ARG GO_LDFLAGS
 ARG GO_TAGS
 
-RUN apk add --no-cache \
-	gcc \
-	binutils-gold \
-	git \
-	musl-dev;
+RUN apt update && apt install -y \
+    gcc \
+    binutils-gold \
+    git \
+    curl \
+    make
+
+RUN curl -sL https://go.dev/dl/go${GO_VER}.${TARGETOS}-${TARGETARCH}.tar.gz | tar zxf - -C /usr/local
+ENV GOBIN="/usr/local/go/bin"
+ENV PATH="$GOBIN:$PATH"
 
 ADD . /build/fabric-ca
 WORKDIR /build/fabric-ca
-RUN go install -tags "${GO_TAGS}" -ldflags "${GO_LDFLAGS}" \
-	github.com/hyperledger/fabric-ca/cmd/fabric-ca-server \
-	&& go install -tags "${GO_TAGS}" -ldflags "${GO_LDFLAGS}" \
-	github.com/hyperledger/fabric-ca/cmd/fabric-ca-client
+
+RUN go install \
+    -tags "${GO_TAGS}" \
+    -ldflags "${GO_LDFLAGS}" \
+    github.com/hyperledger/fabric-ca/cmd/fabric-ca-server
+
+RUN go install \
+    -tags "${GO_TAGS}" \
+    -ldflags "${GO_LDFLAGS}" \
+    github.com/hyperledger/fabric-ca/cmd/fabric-ca-client
 
 
-FROM alpine:${ALPINE_VER}
-RUN apk add --no-cache \
-	tzdata;
+###############################################################################
+# Runtime image
+###############################################################################
+
+ARG UBUNTU_VER
+FROM ubuntu:${UBUNTU_VER}
+
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive apt install -y tzdata
+
 ENV FABRIC_CA_HOME /etc/hyperledger/fabric-ca-server
-COPY --from=builder /go/bin /usr/local/bin
+COPY --from=builder /usr/local/go/bin /usr/local/bin
+
 EXPOSE 7054
-CMD fabric-ca-server start -b admin:adminpw
+
+CMD [ "fabric-ca-server", "start", "-b", "admin:adminpw" ]

--- a/release_notes/v1.5.6-beta3.md
+++ b/release_notes/v1.5.6-beta3.md
@@ -1,0 +1,48 @@
+v1.5.6-beta3 Release Notes - Jan 3, 2023
+===================================
+
+v1.5.6-beta3 is a beta release, providing updates for the following issues in the Fabric CA:
+
+- Builds native arm64 CA binaries for linux and darwin
+- Builds multi-platform CA docker images for arm64 and amd64 with `buildx`
+- Builds CA docker images FROM ubuntu:20.04 (avoid SIGSEGV errors encountered with dynamic builds on musl/alpine libc)
+- Adds debug information for a mysterious [idemix error message](https://github.com/hyperledger/fabric-ca/pull/339)
+- Bumps Go version to 1.18.9
+
+Dependencies
+------------
+
+Fabric CA v1.5.6 has been tested with the following dependencies:
+- Go 1.18.9
+- Ubuntu 20.04 (for Docker images)
+
+
+Changes, Known Issues, and Workarounds
+--------------------------------------
+
+None.
+
+Known Vulnerabilities
+---------------------
+- FABC-174 Commands can be manipulated to delete identities or affiliations
+
+  This vulnerability can be resolved in one of two ways:
+
+    1) Use HTTPS (TLS) so that the authorization header is not in clear text.
+
+    2) The token generation/authentication mechanism was improved to optionally prevent
+       token reuse. As of v1.4 a more secure token can be used by setting environment variable:
+
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false
+
+  However, it cannot be set to false until all clients have
+  been updated to generate the more secure token and tolerate
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false.
+  The Fabric CA client has been updated in v1.4 to generate the more secure token.
+  The Fabric SDKs will be updated by v2.0 timeframe to generate the more secure token,
+  at which time the default for Fabric CA server will change to:
+  FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3=false
+
+Resolved Vulnerabilities
+------------------------
+None.


### PR DESCRIPTION
Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change

- New feature

#### Description

Builds the CA docker image as a multi-stage build, `FROM ubuntu:20.04`. 

With this PR, the base image used to build the CA is now extended from ubuntu.  This resolves several issues related to the golang-alpine base image, which frequently threw SIGSEGV errors when running or linking against the musl libc runtime.  The fabric binaries generated by this build are _dynamically_ linked against the ubuntu / GCC libc, using CGO for the sqlite runtime.


#### Additional details

- https://github.com/hyperledger/fabric/discussions/3876
- https://github.com/hyperledger/fabric/pull/3882

#### Related issues

- https://github.com/hyperledger/fabric/issues/2994

