### PR TITLE
Fix the interop-test build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,8 @@ build/image/fabric-ca/$(DUMMY):
 		--build-arg GO_TAGS=pkcs11 \
 		--build-arg GO_LDFLAGS="${DOCKER_GO_LDFLAGS}" \
 		--build-arg UBUNTU_VER=${UBUNTU_VER} \
+		--build-arg TARGETARCH=$(ARCH) \
+		--build-arg TARGETOS=linux \
 		-t $(DOCKER_NS)/$(TARGET) .
 	docker tag $(DOCKER_NS)/$(TARGET) $(DOCKER_NS)/$(TARGET):$(PROJECT_VERSION)
 	docker tag $(DOCKER_NS)/$(TARGET) $(DOCKER_NS)/$(TARGET):$(DOCKER_TAG)
@@ -124,6 +126,8 @@ build/image/fabric-ca-fvt/$(DUMMY):
 		--build-arg GO_TAGS=pkcs11 \
 		--build-arg GO_LDFLAGS="${DOCKER_GO_LDFLAGS}" \
 		--build-arg PG_VER=${PG_VER} \
+		--build-arg TARGETARCH=$(ARCH) \
+		--build-arg TARGETOS=linux \
 		-t $(DOCKER_NS)/$(TARGET) .
 	@touch $@
 


### PR DESCRIPTION
Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>

#### Type of change

- Bug fix

#### Description

In PR #346, the CA base docker image was switched from alpine-golang to ubuntu.  In the new image, golang is now installed with curl using the `GO_VER`, `TARGETOS`, AND `TARGETARCH` build args.

Depending on the version of Docker installed on the build host, `TARGETOS` and `TARGETARCH` are not always available in the build context.  (In recent Docker versions, these args are implicit in the build context.)  For instance, the fabric-interop tests at Azure are currently failing when trying to build a CA docker image. 

This PR passes the target arch/os from the Makefile to docker as build args.

#### Related issues

- Example [interop test failure](https://dev.azure.com/Hyperledger/Fabric-Test/_build/results?buildId=59844&view=logs&j=a183ae4c-f3a4-5b00-aa7e-db0d3d65a8b9&t=80753e5a-ca3e-565c-aa73-31a966f12831) at azure. 

