### PR TITLE
Update operations_guide.rst

### DIFF
--- a/docs/source/operations_guide.rst
+++ b/docs/source/operations_guide.rst
@@ -318,7 +318,7 @@ signing certificate through an out-of-band process.
     fabric-ca-client enroll -d -u https://rca-org1-admin:rca-org1-adminpw@0.0.0.0:7054
     fabric-ca-client register -d --id.name peer1-org1 --id.secret peer1PW --id.type peer -u https://0.0.0.0:7054
     fabric-ca-client register -d --id.name peer2-org1 --id.secret peer2PW --id.type peer -u https://0.0.0.0:7054
-    fabric-ca-client register -d --id.name admin-org1 --id.secret org1AdminPW --id.type user -u https://0.0.0.0:7054
+    fabric-ca-client register -d --id.name admin-org1 --id.secret org1AdminPW --id.type admin -u https://0.0.0.0:7054
     fabric-ca-client register -d --id.name user-org1 --id.secret org1UserPW --id.type user -u https://0.0.0.0:7054
 
 Setup Org2's CA
@@ -374,7 +374,7 @@ root certificate of CA's TLS certificate has been copied to
     fabric-ca-client enroll -d -u https://rca-org2-admin:rca-org2-adminpw@0.0.0.0:7055
     fabric-ca-client register -d --id.name peer1-org2 --id.secret peer1PW --id.type peer -u https://0.0.0.0:7055
     fabric-ca-client register -d --id.name peer2-org2 --id.secret peer2PW --id.type peer -u https://0.0.0.0:7055
-    fabric-ca-client register -d --id.name admin-org2 --id.secret org2AdminPW --id.type user -u https://0.0.0.0:7055
+    fabric-ca-client register -d --id.name admin-org2 --id.secret org2AdminPW --id.type admin -u https://0.0.0.0:7055
     fabric-ca-client register -d --id.name user-org2 --id.secret org2UserPW --id.type user -u https://0.0.0.0:7055
 
 Setup Peers


### PR DESCRIPTION
FIX: CA Admin identities for org1, org2 must be properly registered as admin

#### Type of change

- Documentation update

#### Description

Following the documentation I got error on [create-and-join-channel](https://hyperledger-fabric-ca.readthedocs.io/en/latest/operations_guide.html#create-and-join-channel) part, getting the following error:
```
Error: got unexpected status: BAD_REQUEST -- error validating channel creation transaction for new channel 'mychannel', could not successfully apply update to template configuration: error authorizing update: error validating DeltaSet: policy for [Group]  /Channel/Application not satisfied: implicit policy evaluation failed - 0 sub-policies were satisfied, but this policy requires 1 of the 'Admins' sub-policies to be satisfied
```
I looked up orderer log to find out that OU being `user` is causing the problem not meeting the policy. I suggest the documentation to use `admin` OU for CA identities of org1 and org2.

#### Additional details

#### Related issues
