### PR TITLE
Bump fabric-ca-fvt to bullseye, Bump postgres and mysql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ PLATFORM=$(shell go env GOOS)-$(shell go env GOARCH)
 RELEASE_VERSION=$(shell echo $(BASE_VERSION) | sed -e  's/^v\(.*\)/\1/')
 PROJECT_VERSION=${RELEASE_VERSION}
 
-PG_VER=11
+PG_VER=13
 
 PKGNAME = github.com/hyperledger/$(PROJECT_NAME)
 
@@ -210,8 +210,8 @@ release/%/bin/fabric-ca-server: $(GO_SOURCE)
 # to the test target you are running i.e. (unit-tests, int-tests, all-tests).
 .PHONY: docker-thirdparty
 docker-thirdparty:
-	docker pull postgres:9.6
-	docker pull mysql:5.7
+	docker pull postgres:13.13
+	docker pull mysql:8.0
 
 .PHONY: dist
 dist: dist-clean release

--- a/docs/source/users-guide.rst
+++ b/docs/source/users-guide.rst
@@ -508,8 +508,8 @@ may skip this section; otherwise, you must configure either PostgreSQL or
 MySQL as described below. Fabric CA supports the following database
 versions in a cluster setup:
 
-- PostgreSQL: 9.5.5 or later
-- MySQL: 5.7 or later
+- PostgreSQL: 13 or later
+- MySQL: 8.0 or later
 
 PostgreSQL
 ^^^^^^^^^^
@@ -622,9 +622,9 @@ The following sample may be added to the Fabric CA server configuration file in
 order to connect to a MySQL database. Be sure to customize the various
 values appropriately. There are limitations on what characters are allowed
 in the database name. Please refer to the following MySQL documentation
-for more information: https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
+for more information: https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
 
-On MySQL 5.7.X, certain modes affect whether the server permits '0000-00-00' as a valid date.
+On MySQL certain modes affect whether the server permits '0000-00-00' as a valid date.
 It might be necessary to relax the modes that MySQL server uses. We want to allow
 the server to be able to accept zero date values.
 
@@ -635,7 +635,7 @@ Please refer to the following MySQL documentation on different modes available
 and select the appropriate settings for the specific version of MySQL that is
 being used.
 
-https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
+https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html
 
 .. code:: yaml
 
@@ -645,6 +645,11 @@ https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
 
 If connecting over TLS to the MySQL server, the ``db.tls.client``
 section is also required as described in the **PostgreSQL** section above.
+
+Note that Fabric CA uses the MySQL "latin1" character set when creating the database.
+MySQL v8.0 changed the default character set from "latin1" to "utf8mb4",
+however the "utf8mb4" character set doesn't work with Fabric CA
+since the additional storage requirements would push existing column and index sizes beyond MySQL maximum sizes.
 
 MySQL SSL Configuration
 """"""""""""""""""""""""

--- a/images/fabric-ca-fvt/Dockerfile
+++ b/images/fabric-ca-fvt/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ARG GO_VER
-FROM golang:${GO_VER}-buster as fabric-ca-builder
+FROM golang:${GO_VER}-bullseye as fabric-ca-builder
 ARG GO_LDFLAGS
 ARG GO_TAGS
 
@@ -17,7 +17,7 @@ RUN go build -tags "${GO_TAGS}" -ldflags "${GO_LDFLAGS}" \
 	-o /usr/local/bin/fabric-ca-client \
 	github.com/hyperledger/fabric-ca/cmd/fabric-ca-client
 
-FROM debian:buster-20210816-slim
+FROM debian:bullseye-20230814-slim
 ARG PG_VER
 
 ENV PATH="/usr/local/go/bin/:${PATH}" \

--- a/images/fabric-ca-fvt/payload/mysql_setup.sh
+++ b/images/fabric-ca-fvt/payload/mysql_setup.sh
@@ -7,14 +7,13 @@ arch=$(uname -m)
 
 export DEBIAN_FRONTEND=noninteractive
 
-# Latest mysql version number can be found at https://dev.mysql.com/downloads/repo/apt/
-echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | debconf-set-selections
-wget https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb
-dpkg -i mysql-apt-config_0.8.22-1_all.deb
+# Latest mysql download can be found at https://dev.mysql.com/downloads/repo/apt/
+# mysql versions and platform support can be found at http://repo.mysql.com/apt/debian/dists/bullseye/ (no arm support)
+echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | debconf-set-selections
+wget https://dev.mysql.com/get/mysql-apt-config_0.8.28-1_all.deb
+dpkg -i mysql-apt-config_0.8.28-1_all.deb
 apt-get update
 apt-get install mysql-server -y
-service mysql start
-mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'mysql'"
 
 mkdir -p /var/run/mysqld
 chown mysql:mysql /var/run/mysqld
@@ -31,4 +30,9 @@ sed -i "s/^[[:blank:]]*#*[[:blank:]]*ssl-ca=.*/ssl-ca=$TLS_BUNDLE/;
         s/^[[:blank:]]*#*[[:blank:]]*ssl-cert=.*/ssl-cert=$TLS_SERVER_CERT/;
         s/^[[:blank:]]*#*[[:blank:]]*ssl-key=.*/ssl-key=$TLS_SERVER_KEY/" $MYCNF || let RC+=1
 chown -R mysql.mysql $MYSQLDATA
+
+/usr/bin/mysqld_safe --sql-mode=STRICT_TRANS_TABLES &
+sleep 5
+mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'mysql'"
+
 exit $RC

--- a/lib/server/db/mysql/mysql.go
+++ b/lib/server/db/mysql/mysql.go
@@ -153,7 +153,11 @@ func (m *Mysql) createDatabase() error {
 	}
 	if !exists {
 		log.Debugf("Creating MySQL Database '%s'", m.dbName)
-		_, err := m.SqlxDB.Exec("CreateDatabase", "CREATE DATABASE "+m.dbName)
+		// Note that Fabric CA uses the MySQL "latin1" character set when creating the database.
+		// MySQL v8.0 changed the default character set from "latin1" to "utf8mb4",
+		// however the "utf8mb4" character set doesn't work with Fabric CA
+		// since the additional storage requirements would push existing column and index sizes beyond MySQL maximum sizes.
+		_, err := m.SqlxDB.Exec("CreateDatabase", "CREATE DATABASE "+m.dbName+" CHARACTER SET latin1 COLLATE latin1_swedish_ci")
 		if err != nil {
 			return errors.Wrap(err, "Failed to execute create database query")
 		}

--- a/scripts/fvt/affiliation_modify_test.sh
+++ b/scripts/fvt/affiliation_modify_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 dbDriver=postgres
 
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/fvt/backwards_comp_test.sh
+++ b/scripts/fvt/backwards_comp_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 TESTCASE="backwards_comp"
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"
@@ -93,7 +95,7 @@ function createDB {
     postgres)
       psql -d postgres -c "CREATE DATABASE $DBNAME" ;;
     mysql)
-      mysql --host=localhost --user=root --password=mysql -e "CREATE DATABASE $DBNAME" ;;
+      mysql --host=localhost --user=root --password=mysql -e "CREATE DATABASE $DBNAME CHARACTER SET latin1 COLLATE latin1_swedish_ci" ;;
     *)
       echo "Invalid database type"
       exit 1
@@ -125,7 +127,7 @@ function loadUsers {
           s/datasource:.*/datasource: host=localhost port=$POSTGRES_PORT user=postgres password=postgres dbname=$DBNAME $postgresTls/" $TESTCONFIG
       ;;
     mysql)
-      mysql --host=localhost --user=root --password=mysql -e "CREATE DATABASE $DBNAME"
+      mysql --host=localhost --user=root --password=mysql -e "CREATE DATABASE $DBNAME CHARACTER SET latin1 COLLATE latin1_swedish_ci"
       mysql --host=localhost --user=root --password=mysql --database=$DBNAME -e "CREATE TABLE IF NOT EXISTS users (id VARCHAR(255) NOT NULL, token blob, type VARCHAR(256), affiliation VARCHAR(1024), attributes TEXT, state INTEGER, max_enrollments INTEGER, PRIMARY KEY (id)) DEFAULT CHARSET=utf8 COLLATE utf8_bin"
       mysql --host=localhost --user=root --password=mysql --database=$DBNAME -e "INSERT INTO users (id, token, type, affiliation, attributes, state, max_enrollments) VALUES ('registrar', '', 'user', 'org2', '[{\"name\": \"hf.Registrar.Roles\", \"value\": \"user,peer,client\"},{\"name\": \"hf.Revoker\", \"value\": \"true\"}]', '0', '-1')"
       mysql --host=localhost --user=root --password=mysql --database=$DBNAME -e "INSERT INTO users (id, token, type, affiliation, attributes, state, max_enrollments) VALUES ('notregistrar', '', 'user', 'org2', '[{\"name\": \"hf.Revoker\", \"value\": \"true\"}]', '0', '-1')"
@@ -219,7 +221,7 @@ for driver in sqlite3 postgres mysql; do
     ;;
   mysql)
     mysql --host=localhost --user=root --password=mysql -e "DROP DATABASE fabric_ca"
-    mysql --host=localhost --user=root --password=mysql -e "CREATE DATABASE fabric_ca"
+    mysql --host=localhost --user=root --password=mysql -e "CREATE DATABASE fabric_ca CHARACTER SET latin1 COLLATE latin1_swedish_ci"
     mysql --host=localhost --user=root --password=mysql --database=fabric_ca -e "CREATE TABLE IF NOT EXISTS properties (property VARCHAR(255), value VARCHAR(256), PRIMARY KEY(property))"
     mysql --host=localhost --user=root --password=mysql --database=fabric_ca -e "INSERT INTO properties (property, value) Values ('identity.level', '9')"
     ;;

--- a/scripts/fvt/cdp_exploit_test.sh
+++ b/scripts/fvt/cdp_exploit_test.sh
@@ -4,6 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 RC=0
 CADOMAIN="FVT"
 : ${TESTCASE:="crl_limit"}

--- a/scripts/fvt/certificates_test.sh
+++ b/scripts/fvt/certificates_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 : ${TESTCASE:="certificates"}
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"

--- a/scripts/fvt/cluster_test.sh
+++ b/scripts/fvt/cluster_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 : ${TESTCASE="ca_cluster"}
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"

--- a/scripts/fvt/db_smoke_test.sh
+++ b/scripts/fvt/db_smoke_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 MYSQLSMOKECONFIG=$FABRIC_CA_DATA/smoke/caconfig.yml
 

--- a/scripts/fvt/enrollments_test.sh
+++ b/scripts/fvt/enrollments_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"
 CA_CFG_PATH="/tmp/fabric-ca/enrollments"

--- a/scripts/fvt/gencsr_test.sh
+++ b/scripts/fvt/gencsr_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 : ${TESTCASE:=gencsr}
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 CA_CFG_PATH="/tmp/$TESTCASE"

--- a/scripts/fvt/group_test.sh
+++ b/scripts/fvt/group_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"
 RC=0

--- a/scripts/fvt/idemix_test.sh
+++ b/scripts/fvt/idemix_test.sh
@@ -6,6 +6,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 : ${TESTCASE:="idemix"}
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 CA_CFG_PATH="/tmp/idemixTesting"

--- a/scripts/fvt/ident_modify_test.sh
+++ b/scripts/fvt/ident_modify_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 : ${TESTCASE="ident_modify"}
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"

--- a/scripts/fvt/intermediateca_test.sh
+++ b/scripts/fvt/intermediateca_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 : ${TESTCASE:="intermediateca-test"}
 TDIR=/tmp/$TESTCASE
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/fvt/keys_test.sh
+++ b/scripts/fvt/keys_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 : ${TESTCASE="keys"}
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"

--- a/scripts/fvt/ldap_test.sh
+++ b/scripts/fvt/ldap_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 : ${TESTNAME:=ldap}
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 TESTDIR="/tmp/$TESTNAME"

--- a/scripts/fvt/multica_test.sh
+++ b/scripts/fvt/multica_test.sh
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
 
 : ${TESTCASE:="multica-test"}
 TDIR=/tmp/$TESTCASE

--- a/scripts/fvt/passwordsInLog_test.sh
+++ b/scripts/fvt/passwordsInLog_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 function rmConfigFiles() {
    rm -rf $TESTDIR/ca-cert.pem \
           $TESTDIR/fabric-ca-server-config.yaml \

--- a/scripts/fvt/postgres_test.sh
+++ b/scripts/fvt/postgres_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 TESTCASE="postgres"
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"

--- a/scripts/fvt/reenroll_test.sh
+++ b/scripts/fvt/reenroll_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"
 PKI="$SCRIPTDIR/utils/pki"

--- a/scripts/fvt/reregister_test.sh
+++ b/scripts/fvt/reregister_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"
 

--- a/scripts/fvt/revoke_test.sh
+++ b/scripts/fvt/revoke_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 export CA_CFG_PATH="/tmp/revoke_test"
 RC=0

--- a/scripts/fvt/roundrobin_test.sh
+++ b/scripts/fvt/roundrobin_test.sh
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x # print commands in case of failure (the log won't get printed upon success)
+
 SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 . "$SCRIPTDIR/fabric-ca_utils"
 HOST="127.0.0.1:10888"

--- a/scripts/run_fvt_tests
+++ b/scripts/run_fvt_tests
@@ -30,6 +30,7 @@ function runTest() {
   ${1} >>$RESULTLOG 2>&1
   rc=$?
   test $rc -eq 0 && echo PASSED || echo FAILED
+  # print the log only upon test failure
   test $rc -ne 0 && awk -v b="$TESTCASE" -v e="test ended." '$0~b,$0~e' $RESULTLOG
   RC=$((RC + rc))
   "$SCRIPTDIR/fabric-ca_setup.sh" -R >/dev/null 2>&1


### PR DESCRIPTION
Bump fabric-ca-fvt from debian buster to bullseye,
required since Go 1.21 is only available on the bullseye image.

bullseye requires updating to Postgres 13 and mysql 8.0,
the current LTS releases.

Since the prior databases Postgres 11 and mysql 5.7 are out of support,
update the supported database statements accordingly.

mysql 8.0 changed how to start and stop the db.

Added test failure logging to improve troubleshooting capability.