### PR TITLE
Make the debug flag visible in --help and docs

### DIFF
--- a/docs/source/servercli.rst
+++ b/docs/source/servercli.rst
@@ -44,6 +44,7 @@ Fabric-CA Server's CLI
           --db.tls.client.certfile string             PEM-encoded certificate file when mutual authenticate is enabled
           --db.tls.client.keyfile string              PEM-encoded key file when mutual authentication is enabled
           --db.type string                            Type of database; one of: sqlite3, postgres, mysql (default "sqlite3")
+      -d, --debug                                     Enable debug level logging (slows server)
       -h, --help                                      help for fabric-ca-server
       -H, --home string                               Server's home directory (default "/etc/hyperledger/fabric-ca")
           --idemix.curve string                       Name of the curve among {'amcl.Fp256bn', 'gurvy.Bn254', 'amcl.Fp256Miraclbn'}, defaults to 'amcl.Fp256bn' (default "amcl.Fp256bn")

--- a/lib/serverconfig.go
+++ b/lib/serverconfig.go
@@ -34,7 +34,7 @@ type ServerConfig struct {
 	// Cross-Origin Resource Sharing settings for the server
 	CORS CORS
 	// Enables debug logging
-	Debug bool `def:"false" opt:"d" help:"Enable debug level logging" hide:"true"`
+	Debug bool `def:"false" opt:"d" help:"Enable debug level logging (slows server)"`
 	// Sets the logging level on the server
 	LogLevel string `help:"Set logging level (info, warning, debug, error, fatal, critical)"`
 	// TLS for the server's listening endpoint

--- a/scripts/regenDocs
+++ b/scripts/regenDocs
@@ -215,6 +215,6 @@ echo "Doc generation completed"
 # Only checking status under docs/source folder
 cd $docsdir
 if [[ $(git status . --porcelain --untracked-file=no) ]]; then
-    echo "ERROR: New rst documentation files generated that don't match the existing docs, run `make docs` to re-generate the rst documentation files before pushing"
+    echo "ERROR: New rst documentation files generated that don't match the existing docs, run \`make docs\` to re-generate the rst documentation files before pushing"
     exit 1
 fi


### PR DESCRIPTION
The -d flag is used by default in test/demo materials such as hyperledger/fabric-samples, so having the the flag be hidden from the documentation causes confusion. Remove 'hide'; add a warning for why users might not want to use it, since those drawbacks were probably the primary reason it was hidden before.

Also, fix doc gen error by escaping the invalid characters.

Acknowledgement to @jkopczyn for originally submitting this improvement in #288 .

