### PR TITLE
Upgrade to latest urllib3.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-python-markdown-math==0.2
+
 
 alabaster==0.7.13
 Babel==2.12.1
@@ -34,6 +34,6 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-websupport==1.2.4
-typing-extensions==4.7.1
-urllib3==1.26.16
+typing_extensions==4.7.1
+urllib3==1.26.17
 zipp==3.15.0


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Upgrade urllib3 to address https://nvd.nist.gov/vuln/detail/CVE-2023-43804

#### Additional details

I tested it by running `make docs` locally. Didn't see any issues with resultant documentation or with the execution/run.

#### Related issues

N/A

#### Release Note
Should not impact users at all; just needed to keep our docs secure.

