### PR TITLE
Apply the CSS.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,13 +89,7 @@ def placeholderReplace(app, docname, source):
     source[0] = result
 
 def setup(app):
-    ## The next commented line is how you would actually import and use the custom.css.
-    ## It's actually always been overridden by the parameters from the RTD
-    ## theme, so we've never actually seen it.  BHS kept it here in case we
-    ## with to use it, but chances are, we should just throw it out.
-    ##
-    ## The changes are minimal and suboptimal in BHS's opinion.
-    # app.add_css_file('custom.css')
+    app.add_css_file("css/custom.css")
     app.add_config_value('placeholder_replacements', {}, True)
     app.connect('source-read', placeholderReplace)
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description


#### Additional details

We haven't been using the `custom.css` that we have in our `/docs` directory for this whole time. I figured out how to make it applicable again.  This is a proposed change to how the docs look and feel.

#### Related issues

None

#### Release Note

This will have **zero** impact on Fabric-CA functionality, and will only change how the docs are _styled_, not any doc content.