### PR TITLE
Fix jQuery issues in docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -73,7 +73,8 @@ extensions = ['sphinx.ext.autodoc',
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'myst_parser']
+    'myst_parser',
+    'sphinxcontrib.jquery']
 
 # -- Special API Accesses -------------------------------------------------
 # They create an instance of the Sphinx object, documented here


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

Try to fix docs so that jQuery loads on readthedocs.

#### Additional details

https://github.com/readthedocs/readthedocs.org/issues/10159#issuecomment-1478717074 has a temp fix that I'm trying.

#### Related issues

* https://github.com/readthedocs/readthedocs.org/issues/10159

#### Release Note

No impact to Fabric CA functionality. 