### PR TITLE
Use fabric-lib-go v1.1.0 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/grantae/certinfo v0.0.0-20170412194111-59d56a35515b
 	github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2
-	github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182
+	github.com/hyperledger/fabric-lib-go v1.1.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2 h1:B1Nt8hKb//KvgGRprk0h1t4lCnwhE9/ryb1WqfZbV+M=
 github.com/hyperledger/fabric-amcl v0.0.0-20230602173724-9e02669dceb2/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
-github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182 h1:O747XXWoCBDoFqMayEwvEyyYD+LIMY/3r/B78xZsbYU=
-github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
+github.com/hyperledger/fabric-lib-go v1.1.0 h1:iVjRr0oxqNn2P0SH2UCiOdLak56kqn/YJ6A/wnxNNaU=
+github.com/hyperledger/fabric-lib-go v1.1.0/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/AlekSi/gocov-xml v0.0.0-20190121064608-3a14fb1c4737
 	github.com/axw/gocov v1.0.0
-	github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182
+	github.com/hyperledger/fabric-lib-go v1.1.0
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/tools v0.17.0

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1420,8 +1420,8 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182 h1:O747XXWoCBDoFqMayEwvEyyYD+LIMY/3r/B78xZsbYU=
-github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
+github.com/hyperledger/fabric-lib-go v1.1.0 h1:iVjRr0oxqNn2P0SH2UCiOdLak56kqn/YJ6A/wnxNNaU=
+github.com/hyperledger/fabric-lib-go v1.1.0/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -148,7 +148,7 @@ github.com/hyperledger/fabric-amcl/amcl
 github.com/hyperledger/fabric-amcl/amcl/FP256BN
 github.com/hyperledger/fabric-amcl/core
 github.com/hyperledger/fabric-amcl/core/FP256BN
-# github.com/hyperledger/fabric-lib-go v1.0.1-0.20240216124656-9f79bd087182
+# github.com/hyperledger/fabric-lib-go v1.1.0
 ## explicit; go 1.20
 github.com/hyperledger/fabric-lib-go/bccsp
 github.com/hyperledger/fabric-lib-go/bccsp/factory


### PR DESCRIPTION
Transition from the fabric-lib-go temporary branch to the actual release v1.1.0.

This is the release that includes the common
bccsp, metrics, and flogging packages that
are shared across fabric and fabric-ca.