### PR TITLE
Bump actions/download-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Login to the ${{ env.DOCKER_REGISTRY }} Container Registry
         uses: docker/login-action@v3
@@ -125,10 +125,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout Fabric CA Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download Artifacts
         id: download
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Release Fabric CA Version
         uses: ncipollo/release-action@v1
         with:


### PR DESCRIPTION
download-artifact needs to be v4 because
upload-artifact is already v4.

Also bump actions/checkout to v4.
