### PR TITLE
Bump Go to 1.23.1

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ on:
 env:
   GOPATH: /opt/go
   PATH: /opt/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GO_VER: 1.22.4
+  GO_VER: 1.23.1
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
     tags: [ v1.* ]
 
 env:
-  GO_VER: 1.22.4
+  GO_VER: 1.23.1
   UBUNTU_VER: 20.04
   DOCKER_REGISTRY: ${{ github.repository_owner == 'hyperledger' && 'docker.io' || 'ghcr.io' }}
   IMAGE_NAME: ${{ github.repository }}

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 
 PROJECT_NAME = fabric-ca
 
-GO_VER = 1.22.4
+GO_VER = 1.23.1
 UBUNTU_VER ?= 20.04
 DEBIAN_VER ?= stretch
 BASE_VERSION ?= v1.5.12

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The remainder of this guide is intended for developers contributing to Fabric CA
 
 ## Prerequisites
 
-* Go 1.22 installation or later
+* Go 1.23 installation or later
 * docker version 17.03 or later
 * docker-compose version 1.11 or later
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-ca
 
-go 1.22
+go 1.23.1
 
 require (
 	github.com/IBM/idemix v0.0.2-0.20231011101252-a4feda90f3f7


### PR DESCRIPTION
Bump Go to 1.23.1.
Also update go.mod to use three digit version to indicate toolchain version (most Go projects have switched to this approach at this point).