### PR TITLE
Change default for V1_3 compatibility to false

### DIFF
--- a/lib/server.go
+++ b/lib/server.go
@@ -330,14 +330,13 @@ func (s *Server) initConfig() (err error) {
 	// Make file names absolute
 	s.makeFileNamesAbsolute()
 
-	compModeStr := os.Getenv("FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3")
-	if compModeStr == "" {
-		compModeStr = "true" // TODO: Change default to false once all clients have been updated to use the new authorization header
-	}
-
-	s.Config.CompMode1_3, err = strconv.ParseBool(compModeStr)
-	if err != nil {
-		return errors.WithMessage(err, "Invalid value for boolean environment variable 'FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3'")
+	if compModeStr := os.Getenv("FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3"); compModeStr == "" {
+		s.Config.CompMode1_3 = false
+	} else {
+		s.Config.CompMode1_3, err = strconv.ParseBool(compModeStr)
+		if err != nil {
+			return errors.WithMessage(err, "Invalid value for boolean environment variable 'FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3'")
+		}
 	}
 
 	return nil

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -50,7 +50,6 @@ func TestECCreateToken(t *testing.T) {
 	tok, err := CreateToken(bccsp, cert, privKey, "GET", "/enroll", body)
 	assert.NoError(t, err, "CreateToken failed")
 
-	os.Setenv("FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3", "false") // Test new token
 	_, err = VerifyToken(bccsp, tok, "GET", "/enroll", body, false)
 	assert.NoError(t, err, "VerifyToken failed")
 
@@ -87,7 +86,7 @@ func TestECCreateToken(t *testing.T) {
 	_, err = VerifyToken(bccsp, oldToken, "GET", "/enroll", body, false)
 	assert.Error(t, err)
 
-	// Test that by default with no environment variable set, the old token is considered valid
+	// With comptability mode enabled, the old token is considered valid
 	os.Unsetenv("FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3")
 	_, err = VerifyToken(bccsp, oldToken, "GET", "/enroll", body, true)
 	assert.NoError(t, err, "Failed to verify token using old token type")


### PR DESCRIPTION
There should be no need to maintain compatibility with insecure tokens from Fabric v1.3. The default is now to require secure tokens. Compatibility with the old insecure tokens can still be enabled by settings the FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3 environment variable to "true".

Closes #434