### PR TITLE
Add config debug

### DIFF
--- a/cmd/fabric-ca-server/main_test.go
+++ b/cmd/fabric-ca-server/main_test.go
@@ -565,3 +565,59 @@ func TestOperationsTLSCertKeyConfig(t *testing.T) {
 	assert.Equal(t, cmd.cfg.Operations.TLS.CertFile, filepath.Join(homeDir, certFile))
 	assert.Equal(t, cmd.cfg.Operations.TLS.KeyFile, filepath.Join(homeDir, keyFile))
 }
+
+func TestRemoveSensitiveLines(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name: "No sensitive lines",
+			input: []string{
+				"username: admin",
+				"server: localhost",
+				"port: 8080",
+			},
+			expected: []string{
+				"username: admin",
+				"server: localhost",
+				"port: 8080",
+			},
+		},
+		{
+			name: "Remove password and secret",
+			input: []string{
+				"username: admin",
+				"password: 12345",
+				"api_secret: xyz",
+				"server: localhost",
+			},
+			expected: []string{
+				"username: admin",
+				"server: localhost",
+			},
+		},
+		{
+			name: "Mixed case sensitive words",
+			input: []string{
+				"User: root",
+				"PassWord: 1234",
+				"Secure_Pw: mypassword",
+				"Ldap URL: ldap://server",
+				"Port: 22",
+			},
+			expected: []string{
+				"User: root",
+				"Port: 22",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := removeSensitiveLines(tc.input)
+			assert.Equal(t, tc.expected, result, "Filtered lines should match expected output")
+		})
+	}
+}

--- a/lib/server.go
+++ b/lib/server.go
@@ -331,8 +331,10 @@ func (s *Server) initConfig() (err error) {
 	s.makeFileNamesAbsolute()
 
 	if compModeStr := os.Getenv("FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3"); compModeStr == "" {
+		log.Info("FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3 not set, defaulting to false")
 		s.Config.CompMode1_3 = false
 	} else {
+		log.Infof("Using FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3 value of %s", compModeStr)
 		s.Config.CompMode1_3, err = strconv.ParseBool(compModeStr)
 		if err != nil {
 			return errors.WithMessage(err, "Invalid value for boolean environment variable 'FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3'")

--- a/util/util.go
+++ b/util/util.go
@@ -233,8 +233,9 @@ func VerifyToken(csp bccsp.BCCSP, token string, method, uri string, body []byte,
 	}
 
 	valid, validErr := csp.Verify(pk2, sig, digest, nil)
+
 	if compMode1_3 && !valid {
-		log.Debugf("Failed to verify token based on new authentication header requirements: %s", err)
+		log.Debugf("Failed to verify token based on new authentication header requirements (initial validation error: %s), attempting with COMPATIBILITY_MODE_V1_3 verification", validErr)
 		sigString := b64Body + "." + b64Cert
 		digest, digestError := csp.Hash([]byte(sigString), &bccsp.SHAOpts{})
 		if digestError != nil {


### PR DESCRIPTION
Changing V1_3 compatibility mode in https://github.com/hyperledger/fabric-ca/pull/435  has caused some user confusion, some additional debug logging will help:

- Info log FABRIC_CA_SERVER_COMPATIBILITY_MODE_V1_3 setting
- Debug log when falling back to COMPATIBILITY_MODE_V1_3 authentication header validation

Also take this opportunity to log the entire config upon startup to be consistent with core Fabric:

- Info log CA config upon startup
