### PR TITLE
clarify description for REST API

### DIFF
--- a/swagger/openapi.json
+++ b/swagger/openapi.json
@@ -217,7 +217,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "**basic** <base64 encoding of userid:password> (OR) **token** <An enrollment token consisting of two base 64 encoded parts separated by a period:  an enrollment certificate; a signature over the certificate and body of request>",
+            "description": "**basic** <base64 encoding of userid:password> (OR) **token** <An enrollment token consisting of two base 64 encoded parts separated by a period:  an enrollment certificate; a signature over the HTTP method, URL path, request body, and the certificate.>",
             "required": true,
             "schema": {
               "type": "string"
@@ -2022,7 +2022,7 @@
       "enrollmentToken": {
         "name": "Authorization",
         "in": "header",
-        "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+        "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
         "required": true,
         "schema": {
           "type": "string"

--- a/swagger/swagger-fabric-ca.json
+++ b/swagger/swagger-fabric-ca.json
@@ -416,7 +416,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "**basic** <base64 encoding of userid:password> (OR) **token** <An enrollment token consisting of two base 64 encoded parts separated by a period:  an enrollment certificate; a signature over the certificate and body of request>",
+            "description": "**basic** <base64 encoding of userid:password> (OR) **token** <An enrollment token consisting of two base 64 encoded parts separated by a period:  an enrollment certificate; a signature over the HTTP method, URL path, request body, and the certificate.>",
             "required": true,
             "type": "string"
           },
@@ -706,7 +706,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },
@@ -882,7 +882,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },
@@ -1043,7 +1043,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },
@@ -1190,7 +1190,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },
@@ -1318,7 +1318,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           }
@@ -1404,7 +1404,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },
@@ -1541,7 +1541,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           }
@@ -1634,7 +1634,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },
@@ -1762,7 +1762,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           }
@@ -1850,7 +1850,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           }
@@ -1995,7 +1995,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },
@@ -2206,7 +2206,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           }
@@ -2346,7 +2346,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },
@@ -2551,7 +2551,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           }
@@ -2685,7 +2685,7 @@
           {
             "name": "Authorization",
             "in": "header",
-            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the certificate and body of request.",
+            "description": "An enrollment token consisting of two base 64 encoded parts separated by a period:   \n* an enrollment certificate;   \n* a signature over the HTTP method, URL path, request body, and the certificate.",
             "required": true,
             "type": "string"
           },


### PR DESCRIPTION
#### Type of change

- Documentation update
 
#### Description

Clarified the REST API description for the Authorization header to avoid confusion when building valid token.
