### PR TITLE
[fabric-ca-client] Added CLI flags to write enrollment output files at custom paths

### DIFF
--- a/cmd/fabric-ca-client/command/getcainfo.go
+++ b/cmd/fabric-ca-client/command/getcainfo.go
@@ -156,10 +156,16 @@ func storeCAChain(config *lib.ClientConfig, si *lib.GetCAInfoResponse) error {
 		}
 	}
 
-	// Store the root certificates in the "cacerts" msp folder
+	// Store the root certificates in the "cacerts" msp folder, or at the custom path if set.
 	certBytes := bytes.Join(rootBlks, []byte(""))
 	if len(certBytes) > 0 {
-		if config.Enrollment.Profile == "tls" {
+		if config.MyCACertFile != "" {
+			dst := path.Join(mspDir, config.MyCACertFile)
+			err := storeToFile("CA certificate", path.Dir(dst), path.Base(dst), certBytes)
+			if err != nil {
+				return err
+			}
+		} else if config.Enrollment.Profile == "tls" {
 			err := storeToFile("TLS root CA certificate", tlsRootCACertsDir, tlsfname, certBytes)
 			if err != nil {
 				return err

--- a/cmd/fabric-ca-client/command/getcainfo.go
+++ b/cmd/fabric-ca-client/command/getcainfo.go
@@ -160,8 +160,15 @@ func storeCAChain(config *lib.ClientConfig, si *lib.GetCAInfoResponse) error {
 	certBytes := bytes.Join(rootBlks, []byte(""))
 	if len(certBytes) > 0 {
 		if config.MyCACertFile != "" {
-			dst := path.Join(mspDir, config.MyCACertFile)
-			err := storeToFile("CA certificate", path.Dir(dst), path.Base(dst), certBytes)
+			dst, err := util.MakeFileAbsWithinDir(config.MyCACertFile, mspDir)
+			if err != nil {
+				return err
+			}
+			desc := "root CA certificate"
+			if config.Enrollment.Profile == "tls" {
+				desc = "TLS root CA certificate"
+			}
+			err = storeToFile(desc, filepath.Dir(dst), filepath.Base(dst), certBytes)
 			if err != nil {
 				return err
 			}

--- a/cmd/fabric-ca-client/command/main_test.go
+++ b/cmd/fabric-ca-client/command/main_test.go
@@ -283,6 +283,109 @@ func TestEnroll(t *testing.T) {
 	}
 }
 
+func TestEnrollCustomOutputFiles(t *testing.T) {
+	adminHome := filepath.Join(tdDir, "customoutputhome")
+	err := os.RemoveAll(adminHome)
+	if err != nil {
+		t.Fatalf("Failed to remove directory %s: %s", adminHome, err)
+	}
+	defer os.RemoveAll(adminHome)
+
+	srv := setupEnrollTest(t)
+	defer stopAndCleanupServer(t, srv)
+
+	err = RunMain([]string{
+		cmdName, "enroll", "-d", "-u", enrollURL, "-H", adminHome,
+		"--myskfile", "server.key",
+		"--mycertfile", "server.crt",
+		"--mycacertfile", "ca.crt",
+	})
+	if err != nil {
+		t.Fatalf("client enroll with custom output files failed: %s", err)
+	}
+
+	mspDir := filepath.Join(adminHome, "msp")
+	keyFile := filepath.Join(mspDir, "server.key")
+	certFile := filepath.Join(mspDir, "server.crt")
+	caCertFile := filepath.Join(mspDir, "ca.crt")
+
+	keyBytes, err := os.ReadFile(keyFile)
+	assert.NoError(t, err, "Failed to read custom private key")
+	assert.NotEmpty(t, keyBytes, "Custom private key file should not be empty")
+
+	_, err = util.GetX509CertificateFromPEMFile(certFile)
+	assert.NoError(t, err, "Failed to parse custom enrollment certificate")
+
+	caCert, err := util.GetX509CertificateFromPEMFile(caCertFile)
+	if assert.NoError(t, err, "Failed to parse custom CA certificate") {
+		assert.True(t, caCert.IsCA, "Custom CA certificate should be a CA certificate")
+	}
+
+	_, err = os.Stat(filepath.Join(mspDir, "signcerts", "cert.pem"))
+	assert.True(t, os.IsNotExist(err), "Default enrollment certificate should not be written")
+	assertFilesInDir(filepath.Join(mspDir, "keystore"), 0, t)
+	assertFilesInDir(filepath.Join(mspDir, "cacerts"), 0, t)
+
+	err = RunMain([]string{
+		cmdName, "reenroll", "-d", "-u", serverURL, "-H", adminHome,
+		"--myskfile", "server.key",
+		"--mycertfile", "server.crt",
+		"--mycacertfile", "ca.crt",
+		"--csr.hosts", "custom-host",
+	})
+	if err != nil {
+		t.Fatalf("client reenroll with custom output files failed: %s", err)
+	}
+
+	renewedKeyBytes, err := os.ReadFile(keyFile)
+	assert.NoError(t, err, "Failed to read renewed custom private key")
+	assert.NotEmpty(t, renewedKeyBytes, "Renewed custom private key file should not be empty")
+	err = util.CheckHostsInCert(certFile, "custom-host")
+	assert.NoError(t, err, "Renewed custom enrollment certificate should include requested host")
+	renewedCACert, err := util.GetX509CertificateFromPEMFile(caCertFile)
+	if assert.NoError(t, err, "Failed to parse renewed custom CA certificate") {
+		assert.True(t, renewedCACert.IsCA, "Renewed custom CA certificate should be a CA certificate")
+	}
+}
+
+func TestEnrollCustomOutputFilesRejectPathEscapes(t *testing.T) {
+	defer os.RemoveAll(filepath.Join(tdDir, "customoutputescape"))
+
+	srv := setupEnrollTest(t)
+	defer stopAndCleanupServer(t, srv)
+
+	testcases := []struct {
+		name string
+		flag string
+		file string
+	}{
+		{name: "private key", flag: "--myskfile", file: "../key.pem"},
+		{name: "enrollment certificate", flag: "--mycertfile", file: "../cert.pem"},
+		{name: "CA certificate", flag: "--mycacertfile", file: "../ca.pem"},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			adminHome := filepath.Join(tdDir, "customoutputescape", strings.ReplaceAll(testcase.name, " ", "-"))
+			err := os.RemoveAll(adminHome)
+			if err != nil {
+				t.Fatalf("Failed to remove directory %s: %s", adminHome, err)
+			}
+			defer os.RemoveAll(adminHome)
+
+			err = RunMain([]string{
+				cmdName, "enroll", "-d", "-u", enrollURL, "-H", adminHome,
+				testcase.flag, testcase.file,
+			})
+			assert.Error(t, err, "enroll should reject path escape for %s", testcase.name)
+
+			escapedFile := filepath.Join(filepath.Dir(filepath.Join(adminHome, "msp")), filepath.Base(testcase.file))
+			_, statErr := os.Stat(escapedFile)
+			assert.True(t, os.IsNotExist(statErr), "Path escape should not write %s", escapedFile)
+		})
+	}
+}
+
 // Tests expiration of enrollment certificate is not after the expiration
 // of the CA certificate that issued the enrollment certificate.
 func TestEnrollmentCertExpiry(t *testing.T) {

--- a/docs/source/clientcli.rst
+++ b/docs/source/clientcli.rst
@@ -48,7 +48,10 @@ Fabric-CA Client's CLI
           --idemix.curve string          The identity mixer curve ID to use among {'amcl.Fp256bn', 'gurvy.Bn254', 'amcl.Fp256Miraclbn'} (default "amcl.Fp256bn")
           --loglevel string              Set logging level (info, warning, debug, error, fatal, critical)
       -M, --mspdir string                Membership Service Provider directory (default "msp")
+          --mycacertfile string          [Optional]: Path relative to the MSP directory where the CA certificate is written
+          --mycertfile string            [Optional]: Path relative to the MSP directory where the enrollment certificate is written
       -m, --myhost string                Hostname to include in the certificate signing request during enrollment (default "$HOSTNAME")
+          --myskfile string              [Optional]: Path relative to the MSP directory where the private key is written
       -a, --revoke.aki string            AKI (Authority Key Identifier) of the certificate to be revoked
       -e, --revoke.name string           Identity whose certificates should be revoked
       -r, --revoke.reason string         Reason for revocation

--- a/docs/source/clientcli.rst
+++ b/docs/source/clientcli.rst
@@ -48,10 +48,10 @@ Fabric-CA Client's CLI
           --idemix.curve string          The identity mixer curve ID to use among {'amcl.Fp256bn', 'gurvy.Bn254', 'amcl.Fp256Miraclbn'} (default "amcl.Fp256bn")
           --loglevel string              Set logging level (info, warning, debug, error, fatal, critical)
       -M, --mspdir string                Membership Service Provider directory (default "msp")
-          --mycacertfile string          [Optional]: Path relative to the MSP directory where the CA certificate is written
-          --mycertfile string            [Optional]: Path relative to the MSP directory where the enrollment certificate is written
+          --mycacertfile string          [Optional]: Path within the MSP directory where the root CA certificate is written
+          --mycertfile string            [Optional]: Path within the MSP directory where the enrollment certificate is written
       -m, --myhost string                Hostname to include in the certificate signing request during enrollment (default "$HOSTNAME")
-          --myskfile string              [Optional]: Path relative to the MSP directory where the private key is written
+          --myskfile string              [Optional]: Path within the MSP directory where the private key is written
       -a, --revoke.aki string            AKI (Authority Key Identifier) of the certificate to be revoked
       -e, --revoke.name string           Identity whose certificates should be revoked
       -r, --revoke.reason string         Reason for revocation

--- a/lib/client.go
+++ b/lib/client.go
@@ -111,7 +111,15 @@ func (c *Client) Init() error {
 		if err != nil {
 			return errors.Wrap(err, "Failed to create signcerts directory")
 		}
-		c.certFile = path.Join(certDir, "cert.pem")
+		if cfg.MyCertFile != "" {
+			certFile := path.Join(mspDir, cfg.MyCertFile)
+			if err = os.MkdirAll(path.Dir(certFile), 0o755); err != nil {
+				return errors.Wrap(err, "Failed to create directory for cert file")
+			}
+			c.certFile = certFile
+		} else {
+			c.certFile = path.Join(certDir, "cert.pem")
+		}
 
 		// CA certs directory
 		c.caCertsDir = path.Join(mspDir, "cacerts")
@@ -321,11 +329,35 @@ func (c *Client) net2LocalCAInfo(net *api.CAInfoResponseNet, local *GetCAInfoRes
 	return nil
 }
 
+// storeCustomKeyFile moves the BCCSP-managed private key to a custom path relative to the MSP
+// directory, if MySkFile is configured.
+func (c *Client) storeCustomKeyFile(key bccsp.Key) error {
+	if c.Config.MySkFile == "" {
+		return nil
+	}
+	src := path.Join(c.Config.MSPDir, "keystore", hex.EncodeToString(key.SKI())+"_sk")
+	dst := path.Join(c.Config.MSPDir, c.Config.MySkFile)
+	if err := os.MkdirAll(path.Dir(dst), 0o700); err != nil {
+		return errors.Wrapf(err, "Failed to create directory for key file '%s'", dst)
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to read key file '%s'", src)
+	}
+	if err = util.WriteFile(dst, data, 0o600); err != nil {
+		return err
+	}
+	return os.Remove(src)
+}
+
 func (c *Client) handleX509Enroll(req *api.EnrollmentRequest) (*EnrollmentResponse, error) {
 	// Generate the CSR
 	csrPEM, key, err := c.GenCSR(req.CSR, req.Name)
 	if err != nil {
 		return nil, errors.WithMessage(err, "Failure generating CSR")
+	}
+	if err := c.storeCustomKeyFile(key); err != nil {
+		return nil, err
 	}
 
 	reqNet := &api.EnrollmentRequestNet{
@@ -446,7 +478,8 @@ func (c *Client) handleIdemixEnroll(req *api.EnrollmentRequest) (*EnrollmentResp
 // identity's X509 credential, and adds the token to the HTTP request. The loaded
 // identity is passed back to the caller.
 func (c *Client) addAuthHeaderForIdemixEnroll(req *api.EnrollmentRequest, id *Identity,
-	body []byte, post *http.Request) error {
+	body []byte, post *http.Request,
+) error {
 	if req.Name != "" && req.Secret != "" {
 		post.SetBasicAuth(req.Name, req.Secret)
 		return nil
@@ -499,7 +532,8 @@ func (c *Client) newEnrollmentResponse(result *api.EnrollmentResponseNet, id str
 
 // newIdemixEnrollmentResponse creates a client idemix enrollment response from a network response
 func (c *Client) newIdemixEnrollmentResponse(identity *Identity, result *api.IdemixEnrollmentResponseNet,
-	sk *math.Zr, id string) (*EnrollmentResponse, error) {
+	sk *math.Zr, id string,
+) (*EnrollmentResponse, error) {
 	log.Debugf("newIdemixEnrollmentResponse %s", id)
 	credBytes, err := util.B64Decode(result.Credential)
 	if err != nil {

--- a/lib/client.go
+++ b/lib/client.go
@@ -98,12 +98,20 @@ func (c *Client) Init() error {
 		}
 		cfg.MSPDir = mspDir
 		// Key directory and file
-		keyDir := path.Join(mspDir, "keystore")
+		keyDir := mspKeystoreDir(mspDir)
 		err = os.MkdirAll(keyDir, 0o700)
 		if err != nil {
 			return errors.Wrap(err, "Failed to create keystore directory")
 		}
-		c.keyFile = path.Join(keyDir, "key.pem")
+		if cfg.MySkFile != "" {
+			// Use the custom key path when loading this identity for later commands (e.g. reenroll)
+			c.keyFile, err = util.MakeFileAbsWithinDir(cfg.MySkFile, mspDir)
+			if err != nil {
+				return err
+			}
+		} else {
+			c.keyFile = filepath.Join(keyDir, "key.pem")
+		}
 
 		// Cert directory and file
 		certDir := path.Join(mspDir, "signcerts")
@@ -112,8 +120,11 @@ func (c *Client) Init() error {
 			return errors.Wrap(err, "Failed to create signcerts directory")
 		}
 		if cfg.MyCertFile != "" {
-			certFile := path.Join(mspDir, cfg.MyCertFile)
-			if err = os.MkdirAll(path.Dir(certFile), 0o755); err != nil {
+			certFile, err := util.MakeFileAbsWithinDir(cfg.MyCertFile, mspDir)
+			if err != nil {
+				return err
+			}
+			if err = os.MkdirAll(filepath.Dir(certFile), 0o755); err != nil {
 				return errors.Wrap(err, "Failed to create directory for cert file")
 			}
 			c.certFile = certFile
@@ -329,15 +340,26 @@ func (c *Client) net2LocalCAInfo(net *api.CAInfoResponseNet, local *GetCAInfoRes
 	return nil
 }
 
+func mspKeystoreDir(mspDir string) string {
+	return filepath.Join(mspDir, "keystore")
+}
+
+func bccspKeyFile(mspDir string, key bccsp.Key) string {
+	return filepath.Join(mspKeystoreDir(mspDir), hex.EncodeToString(key.SKI())+"_sk")
+}
+
 // storeCustomKeyFile moves the BCCSP-managed private key to a custom path relative to the MSP
 // directory, if MySkFile is configured.
 func (c *Client) storeCustomKeyFile(key bccsp.Key) error {
 	if c.Config.MySkFile == "" {
 		return nil
 	}
-	src := path.Join(c.Config.MSPDir, "keystore", hex.EncodeToString(key.SKI())+"_sk")
-	dst := path.Join(c.Config.MSPDir, c.Config.MySkFile)
-	if err := os.MkdirAll(path.Dir(dst), 0o700); err != nil {
+	src := bccspKeyFile(c.Config.MSPDir, key)
+	dst, err := util.MakeFileAbsWithinDir(c.Config.MySkFile, c.Config.MSPDir)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
 		return errors.Wrapf(err, "Failed to create directory for key file '%s'", dst)
 	}
 	data, err := os.ReadFile(src)

--- a/lib/clientconfig.go
+++ b/lib/clientconfig.go
@@ -31,19 +31,22 @@ import (
 
 // ClientConfig is the fabric-ca client's config
 type ClientConfig struct {
-	URL        string `def:"http://localhost:7054" opt:"u" help:"URL of fabric-ca-server"`
-	MSPDir     string `def:"msp" opt:"M" help:"Membership Service Provider directory"`
-	TLS        tls.ClientTLSConfig
-	Enrollment api.EnrollmentRequest
-	CSR        api.CSRInfo
-	ID         api.RegistrationRequest
-	Revoke     api.RevocationRequest
-	CAInfo     api.GetCAInfoRequest
-	CAName     string               `help:"Name of CA"`
-	CSP        *factory.FactoryOpts `mapstructure:"bccsp" hide:"true"`
-	Debug      bool                 `opt:"d" help:"Enable debug level logging" hide:"true"`
-	LogLevel   string               `help:"Set logging level (info, warning, debug, error, fatal, critical)"`
-	Idemix     api.Idemix
+	URL          string `def:"http://localhost:7054" opt:"u" help:"URL of fabric-ca-server"`
+	MSPDir       string `def:"msp" opt:"M" help:"Membership Service Provider directory"`
+	TLS          tls.ClientTLSConfig
+	Enrollment   api.EnrollmentRequest
+	CSR          api.CSRInfo
+	ID           api.RegistrationRequest
+	Revoke       api.RevocationRequest
+	CAInfo       api.GetCAInfoRequest
+	CAName       string               `help:"Name of CA"`
+	CSP          *factory.FactoryOpts `mapstructure:"bccsp" hide:"true"`
+	Debug        bool                 `opt:"d" help:"Enable debug level logging" hide:"true"`
+	LogLevel     string               `help:"Set logging level (info, warning, debug, error, fatal, critical)"`
+	Idemix       api.Idemix
+	MySkFile     string `help:"[Optional]: Path relative to the MSP directory where the private key is written"`
+	MyCertFile   string `help:"[Optional]: Path relative to the MSP directory where the enrollment certificate is written"`
+	MyCACertFile string `help:"[Optional]: Path relative to the MSP directory where the CA certificate is written"`
 }
 
 // Enroll a client given the server's URL and the client's home directory.

--- a/lib/clientconfig.go
+++ b/lib/clientconfig.go
@@ -44,9 +44,9 @@ type ClientConfig struct {
 	Debug        bool                 `opt:"d" help:"Enable debug level logging" hide:"true"`
 	LogLevel     string               `help:"Set logging level (info, warning, debug, error, fatal, critical)"`
 	Idemix       api.Idemix
-	MySkFile     string `help:"[Optional]: Path relative to the MSP directory where the private key is written"`
-	MyCertFile   string `help:"[Optional]: Path relative to the MSP directory where the enrollment certificate is written"`
-	MyCACertFile string `help:"[Optional]: Path relative to the MSP directory where the CA certificate is written"`
+	MySkFile     string `help:"[Optional]: Path within the MSP directory where the private key is written"`
+	MyCertFile   string `help:"[Optional]: Path within the MSP directory where the enrollment certificate is written"`
+	MyCACertFile string `help:"[Optional]: Path within the MSP directory where the root CA certificate is written"`
 }
 
 // Enroll a client given the server's URL and the client's home directory.

--- a/lib/identity.go
+++ b/lib/identity.go
@@ -155,6 +155,9 @@ func (i *Identity) Reenroll(req *api.ReenrollmentRequest) (*EnrollmentResponse, 
 		if err != nil {
 			return nil, err
 		}
+		if err := i.client.storeCustomKeyFile(key); err != nil {
+			return nil, err
+		}
 	}
 
 	reqNet := &api.ReenrollmentRequestNet{

--- a/util/util.go
+++ b/util/util.go
@@ -487,6 +487,22 @@ func MakeFileAbs(file, dir string) (string, error) {
 	return path, nil
 }
 
+// MakeFileAbsWithinDir makes 'file' absolute relative to 'dir' and ensures
+// that 'file' is a local path that does not escape 'dir'.
+func MakeFileAbsWithinDir(file, dir string) (string, error) {
+	if file == "" {
+		return "", nil
+	}
+	if !filepath.IsLocal(file) {
+		return "", errors.Errorf("file path '%s' must be relative and remain within '%s'", file, dir)
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed making '%s' absolute", dir)
+	}
+	return filepath.Join(absDir, file), nil
+}
+
 // MakeFileNamesAbsolute makes all file names in the list absolute, relative to home
 func MakeFileNamesAbsolute(files []*string, home string) error {
 	for _, filePtr := range files {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -317,6 +317,37 @@ func TestMakeFileAbs(t *testing.T) {
 	testMakeFileAbs(t, "../c", "/a/b", "/a/c")
 }
 
+func TestMakeFileAbsWithinDir(t *testing.T) {
+	baseDir := filepath.Join(string(filepath.Separator), "a", "b")
+
+	testcases := []struct {
+		name     string
+		file     string
+		expected string
+		err      bool
+	}{
+		{name: "empty", file: "", expected: ""},
+		{name: "file", file: "server.key", expected: filepath.Join(baseDir, "server.key")},
+		{name: "nested", file: "tls/server.key", expected: filepath.Join(baseDir, "tls", "server.key")},
+		{name: "deep nested", file: "nested/server.crt", expected: filepath.Join(baseDir, "nested", "server.crt")},
+		{name: "parent escape", file: "../server.key", err: true},
+		{name: "deep parent escape", file: "../../ca.crt", err: true},
+		{name: "absolute path", file: filepath.Join(string(filepath.Separator), "server.key"), err: true},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			path, err := MakeFileAbsWithinDir(testcase.file, baseDir)
+			if testcase.err {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, testcase.expected, path)
+		})
+	}
+}
+
 func TestMakeFilesAbs(t *testing.T) {
 	file1 := "a"
 	file2 := "a/b"


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

`fabric-ca-client enroll` writes output files to fixed locations within the MSP directory structure: the private key is stored by the BCCSP keystore under a hash-derived filename (`<ski_hex>_sk`), the enrollment certificate at `signcerts/cert.pem`, and the CA certificate at `[tls]cacerts/<server-url-derived>.pem`. These locations are not configurable and not in line with what `cryptogen` usually generates, making harder the switch from such development tool to `fabric-ca`.

Since we use Fabric-CA within our Fabric-X deployment scripts, we have currently _patched_ this behaviour introducing some extra-steps summarized in the [`cryptogenize.yaml`](https://github.com/LF-Decentralized-Trust-labs/fabric-x-ansible-collection/blob/main/roles/fabric_ca/tasks/client/cryptogenize.yaml) task. However this task introduces unnecessary overhead that we could simply avoid by enhancing the current `fabric-ca-client` binary.

This change adds three optional flags to `ClientConfig`, available to the `enroll` and `reenroll` commands:

- `--myskfile <path>` — path relative to the MSP directory where the private key is written
  (e.g. `server.key` produces `<mspdir>/server.key`)
- `--mycertfile <path>` — path relative to the MSP directory where the enrollment certificate
  is written (e.g. `server.crt` produces `<mspdir>/server.crt`)
- `--mycacertfile <path>` — path relative to the MSP directory where the CA certificate is
  written (e.g. `ca.crt` produces `<mspdir>/ca.crt`)

When a flag is set, the file is written at the specified path instead of the default MSP subdirectory. When a flag is not set, existing behavior is fully preserved.

The flags are registered automatically via `util.RegisterFlags` using the existing struct-tag reflection mechanism, consistent with all other `ClientConfig` fields. They are also bindable via environment variables (`FABRIC_CA_CLIENT_MYSKFILE`, etc.) and the configuration file.

#### Additional details

We have set the flags as `my...` to stick with the convention that we have seen with the flag `--myhost` (which sets the hostname in the CSR). It is used to distinguish output/identity-related flags from connection and TLS flags
(`--tls.client.certfile`, `--tls.client.keyfile`, `--tls.certfiles`), which operate on different files and would be ambiguous with shorter names like `--certfile` or `--keyfile`.

#### Note

After the merge of this PR it would be great if you could release a new version (e.g. `1.5.19`) since we use the Docker images in our deployment scripts and to leverage this new functionality we would need `fabric-ca-client:1.5.19` image.

Thank you!