### PR TITLE
Build with Go 1.26.2 to address CVEs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ on:
 env:
   GOPATH: /opt/go
   PATH: /opt/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GO_VER: 1.26.1
+  GO_VER: 1.26.2
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
     tags: [v1.*]
 
 env:
-  GO_VER: 1.26.1
+  GO_VER: 1.26.2
   UBUNTU_VER: 22.04
   IMAGE_NAME: ${{ github.repository }}
   FABRIC_CA_VER: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 
 PROJECT_NAME = fabric-ca
 
-GO_VER ?= 1.26.1
+GO_VER ?= 1.26.2
 UBUNTU_VER ?= 22.04
 DEBIAN_VER ?= stretch
 BASE_VERSION ?= v1.5.18

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hyperledger/fabric-ca
 
 go 1.25.0
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/IBM/idemix v0.0.2-0.20240913182345-72941a5f41cd


### PR DESCRIPTION
- CVE-2026-33810
- CVE-2026-32283
- CVE-2026-32281
- CVE-2026-32280