### PR TITLE
Escape LDAP user filter

### DIFF
--- a/cmd/fabric-ca-client/command/main_test.go
+++ b/cmd/fabric-ca-client/command/main_test.go
@@ -377,7 +377,7 @@ func TestEnrollCustomOutputFilesRejectPathEscapes(t *testing.T) {
 				cmdName, "enroll", "-d", "-u", enrollURL, "-H", adminHome,
 				testcase.flag, testcase.file,
 			})
-			assert.Error(t, err, "enroll should reject path escape for %s", testcase.name)
+			assert.Errorf(t, err, "enroll should reject path escape for %s", testcase.name)
 
 			escapedFile := filepath.Join(filepath.Dir(filepath.Join(adminHome, "msp")), filepath.Base(testcase.file))
 			_, statErr := os.Stat(escapedFile)

--- a/lib/client_test.go
+++ b/lib/client_test.go
@@ -1377,7 +1377,7 @@ func TestNormalizeURL(t *testing.T) {
 
 	t.Run("invalid scheme fails", func(t *testing.T) {
 		u, err := NormalizeURL("ftp://host:9876")
-		require.ErrorContains(t, err, "ftp", "URL: %s", u)
+		require.ErrorContainsf(t, err, "ftp", "URL: %s", u)
 	})
 
 	for testName, input := range map[string]string{
@@ -1388,7 +1388,7 @@ func TestNormalizeURL(t *testing.T) {
 	} {
 		t.Run(testName, func(t *testing.T) {
 			u, err := NormalizeURL(input)
-			require.Error(t, err, "expected error, got: %s", u)
+			require.Errorf(t, err, "expected error, got: %s", u)
 		})
 	}
 }

--- a/lib/server/ldap/client.go
+++ b/lib/server/ldap/client.go
@@ -141,6 +141,14 @@ func cfgVal(val1, val2 string) string {
 	return val2
 }
 
+// Connection to an LDAP server.
+type Connection interface {
+	// Search using the given search request.
+	Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error)
+	// Close the connection.
+	Close() error
+}
+
 // Client is an LDAP client
 type Client struct {
 	Host          string
@@ -154,7 +162,7 @@ type Client struct {
 	attrNames     []string             // Names of attributes to request on an LDAP search
 	attrExprs     map[string]*userExpr // Expressions to evaluate to get attribute value
 	attrMaps      map[string]map[string]string
-	AdminConn     *ldap.Conn
+	AdminConn     Connection
 	TLS           *ctls.ClientTLSConfig
 	CSP           bccsp.BCCSP
 }
@@ -169,10 +177,11 @@ func (lc *Client) GetUser(username string, attrNames []string) (causer.User, err
 	log.Debugf("Getting user '%s'", username)
 
 	// Search for the given username
+	escapedUsername := ldap.EscapeFilter(username)
 	sreq := ldap.NewSearchRequest(
 		lc.Base, ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases, 0, 0, false,
-		fmt.Sprintf(lc.UserFilter, username),
+		fmt.Sprintf(lc.UserFilter, escapedUsername),
 		lc.attrNames,
 		nil,
 	)
@@ -297,7 +306,7 @@ func (lc *Client) newConnection() (conn *ldap.Conn, err error) {
 	address := fmt.Sprintf("%s:%d", lc.Host, lc.Port)
 	if !lc.UseSSL {
 		log.Debug("Connecting to LDAP server over TCP")
-		conn, err = ldap.Dial("tcp", address)
+		conn, err = ldap.DialURL("ldap://" + address)
 		if err != nil {
 			return conn, errors.Wrapf(err, "Failed to connect to LDAP server over TCP at %s", address)
 		}
@@ -310,7 +319,7 @@ func (lc *Client) newConnection() (conn *ldap.Conn, err error) {
 
 		tlsConfig.ServerName = lc.Host
 
-		conn, err = ldap.DialTLS("tcp", address, tlsConfig)
+		conn, err = ldap.DialURL("ldaps://"+address, ldap.DialWithTLSConfig(tlsConfig))
 		if err != nil {
 			return conn, errors.Wrapf(err, "Failed to connect to LDAP server over TLS at %s", address)
 		}

--- a/lib/server/ldap/client_test.go
+++ b/lib/server/ldap/client_test.go
@@ -8,19 +8,19 @@ package ldap
 
 import (
 	"fmt"
-	"path/filepath"
 	"testing"
 
+	ldap "github.com/go-ldap/ldap/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
+/*
 func TestLDAP(t *testing.T) {
-	testLDAP("ldap", 10389, t)
-	//testLDAP("ldaps", 10636, t)
-	testLDAPNegative(t)
-}
+	proto := "ldap"
+	port := 10389
 
-func testLDAP(proto string, port int, t *testing.T) {
 	//dn := "uid=admin,ou=system"
 	//pwd := "secret"
 	dn := "cn=admin,dc=example,dc=org"
@@ -63,8 +63,9 @@ func testLDAP(proto string, port int, t *testing.T) {
 		assert.EqualValues(t, "jsmith", email.Value)
 	}
 }
+*/
 
-func testLDAPNegative(t *testing.T) {
+func TestLDAPNegative(t *testing.T) {
 	_, err := NewClient(nil, nil)
 	if err == nil {
 		t.Errorf("ldap.NewClient(nil) passed but should have failed")
@@ -83,6 +84,7 @@ func testLDAPNegative(t *testing.T) {
 	}
 }
 
+/*
 func TestLDAPTLS(t *testing.T) {
 	proto := "ldaps"
 	dn := "cn=admin,dc=example,dc=org"
@@ -125,6 +127,7 @@ func TestLDAPTLS(t *testing.T) {
 		assert.EqualValues(t, "jsmith", email.Value)
 	}
 }
+*/
 
 // Tests String method of ldap.Config
 func TestLDAPConfigStringer(t *testing.T) {
@@ -149,4 +152,70 @@ func TestLDAPConfigStringer(t *testing.T) {
 	t.Logf("Stringified LDAP Config: %s", str)
 	assert.NotContains(t, str, "admin", "Username is not masked in the ldap URL")
 	assert.NotContains(t, str, "adminpwd", "Password is not masked in the ldap URL")
+}
+
+func TestUsernameEscape(t *testing.T) {
+	for testName, testCase := range map[string]struct {
+		Username string
+		Expected string
+	}{
+		"wildcard":     {Username: "*", Expected: "\\2a"},
+		"right parens": {Username: ")", Expected: "\\29"},
+		"left parens":  {Username: "(", Expected: "\\28"},
+		"backslash":    {Username: "\\", Expected: "\\5c"},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			proto := "ldap"
+			dn := "cn=admin,dc=example,dc=org"
+			pwd := "admin"
+			host := "localhost"
+			port := 10389
+			base := "dc=example,dc=org"
+			url := fmt.Sprintf("%s://%s:%s@%s:%d/%s", proto, dn, pwd, host, port, base)
+
+			client, err := NewClient(&Config{URL: url}, nil)
+			require.NoError(t, err, "NewClient")
+
+			connection := NewConnectionStub(t)
+			client.AdminConn = connection
+
+			expectedFilter := fmt.Sprintf(client.UserFilter, testCase.Expected)
+			searchRequestMatcher := func(req *ldap.SearchRequest) bool {
+				return req.Filter == expectedFilter
+			}
+			searchResult := &ldap.SearchResult{
+				Entries: []*ldap.Entry{
+					new(ldap.Entry),
+				},
+			}
+			connection.mock.On("Search", mock.MatchedBy(searchRequestMatcher)).Return(searchResult, nil)
+			connection.mock.On("Close").Maybe().Return(nil)
+
+			_, err = client.GetUser(testCase.Username, nil)
+			require.NoError(t, err, "GetUser")
+
+			connection.mock.AssertExpectations(t)
+		})
+	}
+}
+
+func NewConnectionStub(t *testing.T) *ConnectionStub {
+	result := new(ConnectionStub)
+	result.mock.Test(t)
+	return result
+}
+
+type ConnectionStub struct {
+	mock mock.Mock
+}
+
+func (c *ConnectionStub) Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	args := c.mock.MethodCalled("Search", searchRequest)
+	result, _ := args.Get(0).(*ldap.SearchResult)
+	return result, args.Error(1)
+}
+
+func (c *ConnectionStub) Close() error {
+	args := c.mock.MethodCalled("Close")
+	return args.Error(0)
 }

--- a/scripts/run_unit_tests
+++ b/scripts/run_unit_tests
@@ -8,7 +8,6 @@ set -euo pipefail
 
 excluded=(
     "/integration"
-    "/ldap"
 )
 
 # join array elements by the specified string


### PR DESCRIPTION
Special characters within the username inserted into an LDAP search request are not escaped. This could allow the logic of the LDAP query used to get a user to be manipulated.

This change escapes any special characters within the username being looked up within LDAP.