### PR TITLE
Update Go to 1.26.4

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,6 @@ on:
 env:
   GOPATH: /opt/go
   PATH: /opt/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GO_VER: 1.26.3
 
 permissions:
   contents: read
@@ -32,7 +31,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         name: Install Go
         with:
-          go-version: ${{ env.GO_VER }}
+          go-version-file: go.mod
       - run: make dist checks all-tests docs
         name: Run Unit and Integration Tests
   fvt-tests:
@@ -48,6 +47,6 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         name: Install Go
         with:
-          go-version: ${{ env.GO_VER }}
+          go-version-file: go.mod
       - run: make fvt-tests
         name: Run FVT Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
     tags: [v1.*]
 
 env:
-  GO_VER: 1.26.2
   UBUNTU_VER: 22.04
   IMAGE_NAME: ${{ github.repository }}
   FABRIC_CA_VER: ${{ github.ref_name }}
@@ -41,7 +40,7 @@ jobs:
       - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         name: Install Go
         with:
-          go-version: ${{ env.GO_VER }}
+          go-version-file: go.mod
 
       - name: Install GCC cross-compilers
         if: ${{ contains(matrix.platform, 'linux') }}
@@ -87,6 +86,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        id: setup-go
+        with:
+          go-version-file: go.mod
+
       - name: Login to the ${{ matrix.registry }} Container Registry
         uses: docker/login-action@v3
         with:
@@ -112,7 +116,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             UBUNTU_VER=${{ env.UBUNTU_VER }}
-            GO_VER=${{ env.GO_VER }}
+            GO_VER=${{ steps.setup-go.outputs.go-version }}
             GO_TAGS=pkcs11
             GO_LDFLAGS=-X github.com/hyperledger/fabric-ca/lib/metadata.Version=${{ env.FABRIC_CA_VER }}
           outputs: type=image,"name=${{ matrix.registry }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 
 PROJECT_NAME = fabric-ca
 
-GO_VER ?= 1.26.3
+GO_VER ?= $(shell go list -m toolchain | cut -c13-)
 UBUNTU_VER ?= 22.04
 DEBIAN_VER ?= stretch
 BASE_VERSION ?= v1.5.20
@@ -39,7 +39,7 @@ PLATFORM=$(shell go env GOOS)-$(shell go env GOARCH)
 
 # For compatibility with legacy install-fabric.sh conventions, strip the
 # leading semrev 'v' character when preparing dist and release artifacts.
-RELEASE_VERSION=$(shell echo $(BASE_VERSION) | sed -e  's/^v\(.*\)/\1/')
+RELEASE_VERSION=$(shell echo $(BASE_VERSION) | sed 's/^v//')
 PROJECT_VERSION=${RELEASE_VERSION}
 
 PG_VER=17

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hyperledger/fabric-ca
 
 go 1.25.0
 
-toolchain go1.26.3
+toolchain go1.26.4
 
 require (
 	github.com/IBM/idemix v0.0.2-0.20240913182345-72941a5f41cd


### PR DESCRIPTION
Addresses the following security vulnerabilities in Go standard libraries:

- CVE-2026-27145
- CVE-2026-42507

This change also refactors the Makefile and GitHub Actions workflows to use the Go toolchain version from the go.mod instead of duplicating the Go version in multiple locations.