### PR TITLE
Fix client command detection when flags precede subcommand

### DIFF
--- a/cmd/fabric-ca-client/command/root.go
+++ b/cmd/fabric-ca-client/command/root.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package command
 
-import "os"
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
 
 // RunMain is the fabric-ca client main
 func RunMain(args []string) error {
@@ -24,16 +29,28 @@ func RunMain(args []string) error {
 	saveOsArgs := os.Args
 	os.Args = args
 
-	// Execute the command
-	cmdName := ""
+	ccmd := NewCommand("")
 	if len(args) > 1 {
-		cmdName = args[1]
+		ccmd.name = strings.ToLower(resolveCommandName(ccmd.rootCmd, args[1:]))
 	}
-	ccmd := NewCommand(cmdName)
 	err := ccmd.Execute()
 
 	// Restore original os.Args
 	os.Args = saveOsArgs
 
 	return err
+}
+
+// resolveCommandName returns the top-level subcommand selected by args using
+// the same parsing rules as cobra, so global flags may appear before the
+// subcommand name.
+func resolveCommandName(root *cobra.Command, args []string) string {
+	cmd, _, err := root.Find(args)
+	if err != nil || cmd == nil || cmd == root {
+		return ""
+	}
+	for cmd.Parent() != nil && cmd.Parent() != root {
+		cmd = cmd.Parent()
+	}
+	return cmd.Name()
 }

--- a/cmd/fabric-ca-client/command/root_test.go
+++ b/cmd/fabric-ca-client/command/root_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveCommandName(t *testing.T) {
+	ccmd := NewCommand("")
+
+	testCases := []struct {
+		name     string
+		args     []string
+		expected string
+	}{
+		{
+			name:     "subcommand first",
+			args:     []string{"enroll", "-u", "http://admin:adminpw@localhost:7054"},
+			expected: "enroll",
+		},
+		{
+			name:     "global flags before subcommand",
+			args:     []string{"--loglevel", "warning", "enroll", "-u", "http://admin:adminpw@localhost:7054"},
+			expected: "enroll",
+		},
+		{
+			name:     "global flag with equals before subcommand",
+			args:     []string{"--loglevel=warning", "gencsr", "--csr.cn", "identity"},
+			expected: "gencsr",
+		},
+		{
+			name:     "nested subcommand",
+			args:     []string{"--loglevel", "warning", "identity", "list"},
+			expected: "identity",
+		},
+		{
+			name:     "getcacert alias",
+			args:     []string{"--home", "/tmp/home", "getcacert", "-u", "http://localhost:7054"},
+			expected: "getcainfo",
+		},
+		{
+			name:     "no subcommand",
+			args:     []string{"--loglevel", "warning"},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, resolveCommandName(ccmd.rootCmd, tc.args))
+		})
+	}
+}
+
+func TestEnrollWithGlobalFlagsBeforeSubcommand(t *testing.T) {
+	adminHome := filepath.Join(tdDir, "enrolladminhomeflags")
+
+	err := os.RemoveAll(adminHome)
+	require.NoErrorf(t, err, "Failed to remove directory %s: %s", adminHome, err)
+	defer os.RemoveAll(adminHome)
+
+	srv := setupEnrollTest(t)
+	defer stopAndCleanupServer(t, srv)
+
+	err = RunMain([]string{cmdName, "--loglevel", "warning", "enroll", "-d", "-u", enrollURL, "-H", adminHome})
+	require.NoError(t, err, "enroll should succeed with global flags before subcommand")
+}


### PR DESCRIPTION
## Summary

- Resolve the active subcommand with cobra's `Find` instead of assuming `args[1]` is always the command name
- Fixes incorrect enrollment validation when global flags (e.g. `--loglevel warning`) appear before `enroll`, `gencsr`, `getcacert`, or `getcainfo`
- Add unit tests for command resolution and the reported enroll failure mode

## Problem

`fabric-ca-client --loglevel warning enroll -u ...` was treated as if the subcommand was `warning`, so `ConfigInit` incorrectly required prior enrollment and failed with:

> Enrollment information does not exist. Please execute enroll command first.

## Test plan

- [x] `go test ./cmd/fabric-ca-client/command/ -run 'TestResolveCommandName|TestEnrollWithGlobalFlagsBeforeSubcommand'`
- [x] `go test ./cmd/fabric-ca-client/command/`

Fixes #465