### PR TITLE
Document fabric-ca-client -d debug flag (#426)

### DIFF
--- a/docs/source/clientcli.rst
+++ b/docs/source/clientcli.rst
@@ -47,6 +47,7 @@ Fabric-CA Client's CLI
           --id.type string               Type of identity being registered (e.g. 'peer, app, user') (default "client")
           --idemix.curve string          The identity mixer curve ID to use among {'amcl.Fp256bn', 'gurvy.Bn254', 'amcl.Fp256Miraclbn'} (default "amcl.Fp256bn")
           --loglevel string              Set logging level (info, warning, debug, error, fatal, critical)
+      -d, --debug                        Enable debug level logging
       -M, --mspdir string                Membership Service Provider directory (default "msp")
           --mycacertfile string          [Optional]: Path within the MSP directory where the root CA certificate is written
           --mycertfile string            [Optional]: Path within the MSP directory where the enrollment certificate is written

--- a/docs/source/users-guide.rst
+++ b/docs/source/users-guide.rst
@@ -245,6 +245,13 @@ for convenience.  Additional usage information is provided in following sections
 The following links shows the :doc:`Server Command Line <servercli>` and
 :doc:`Client Command Line <clientcli>`.
 
+Both the Fabric CA server and client support ``-d``/``--debug`` to enable debug
+level logging. The client also supports ``--loglevel`` to set a specific log
+level. Do not use ``-d`` together with ``--loglevel`` on the same command; if
+both are specified, the command fails. To reduce verbosity, omit ``-d`` from
+example commands and use ``--loglevel`` instead (for example,
+``--loglevel warning``).
+
 .. note:: Note that command line options that are string slices (lists) can be
           specified either by specifying the option with comma-separated list
           elements or by specifying the option multiple times, each with a

--- a/lib/clientconfig.go
+++ b/lib/clientconfig.go
@@ -41,7 +41,7 @@ type ClientConfig struct {
 	CAInfo       api.GetCAInfoRequest
 	CAName       string               `help:"Name of CA"`
 	CSP          *factory.FactoryOpts `mapstructure:"bccsp" hide:"true"`
-	Debug        bool                 `opt:"d" help:"Enable debug level logging" hide:"true"`
+	Debug        bool                 `opt:"d" help:"Enable debug level logging"`
 	LogLevel     string               `help:"Set logging level (info, warning, debug, error, fatal, critical)"`
 	Idemix       api.Idemix
 	MySkFile     string `help:"[Optional]: Path within the MSP directory where the private key is written"`


### PR DESCRIPTION
## Summary

- Unhide the `-d`/`--debug` flag on `fabric-ca-client` so it appears in `--help`, consistent with `fabric-ca-server`
- Add the flag to `docs/source/clientcli.rst`
- Document in the user's guide that `-d` enables debug logging and must not be combined with `--loglevel` on the same command

Fixes #426

## Test plan

- [x] `go build ./cmd/fabric-ca-client/...`
- [x] Verified `fabric-ca-client` help will include `-d` after unhiding the flag