### PR TITLE
Add support for `s390x` binary and image build in Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
             platform: linux-amd64
           - image: ubuntu-22.04
             platform: linux-arm64
+          - image: ubuntu-22.04
+            platform: linux-s390x
           - image: macos-latest
             platform: darwin-arm64
           - image: macos-15-intel
@@ -48,6 +50,7 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install gcc-aarch64-linux-gnu
           sudo apt-get -y install gcc-x86-64-linux-gnu
+          sudo apt-get -y install gcc-s390x-linux-gnu
 
       - run: make dist/${{ matrix.platform }}
         name: Compile Binary and Create Tarball
@@ -62,10 +65,11 @@ jobs:
           # <path> of the artifact may include multiple files.
           path: release/${{ matrix.platform }}/*.tar.gz
 
-  # build native image using a different runner for each architecture (faster and more reliable than using qemu to build multi-architecture images on ubuntu-22.04)
-  build-and-push-native-docker-images:
-    name: Build and Push native image
-    runs-on: ${{ matrix.runner }}
+  # build a multi-architecture image (linux/amd64, linux/arm64, linux/s390x) in a single job using
+  # Buildx + QEMU emulation, and push it directly as a multi-arch manifest list.
+  build-and-push-docker-image:
+    name: Build and Push multi-arch image
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: read
@@ -74,10 +78,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          - ubuntu-22.04 # creates linux-amd64 images
-          - ubuntu-22.04-arm # creates linux-arm64 images
-
         # Dynamic matrix
         # If owner is 'hyperledger' run job for Docker Hub and ghcr, otherwise for personal forks just run job for ghcr
         registry: ${{ fromJSON(github.repository_owner == 'hyperledger' && '["docker.io", "ghcr.io"]' || '["ghcr.io"]') }}
@@ -91,76 +91,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Login to the ${{ matrix.registry }} Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ matrix.registry }}
-          username: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
-          password: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU (for cross-platform builds)
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ matrix.registry }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push
-        id: build-and-push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: images/fabric-ca/Dockerfile
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            UBUNTU_VER=${{ env.UBUNTU_VER }}
-            GO_VER=${{ steps.setup-go.outputs.go-version }}
-            GO_TAGS=pkcs11
-            GO_LDFLAGS=-X github.com/hyperledger/fabric-ca/lib/metadata.Version=${{ env.FABRIC_CA_VER }}
-          outputs: type=image,"name=${{ matrix.registry }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p ${{ runner.temp }}/digests/${{ matrix.registry }}
-          digest="${{ steps.build-and-push.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${{ matrix.registry }}/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: digests-${{ matrix.registry }}-${{ matrix.runner }}
-          path: ${{ runner.temp }}/digests/${{ matrix.registry }}/*
-          if-no-files-found: error
-          retention-days: 1
-
-  # This job merges the architecture-specific digests for the images created above
-  # and creates a multi-architecture image manifest with user-friendly tags
-  merge-and-push-multi-arch-image:
-    name: Merge and Push multi-arch image
-    runs-on: ubuntu-22.04
-    needs:
-      - build-and-push-native-docker-images
-
-    permissions:
-      contents: read
-      packages: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        # Dynamic matrix
-        # If owner is 'hyperledger' run job for Docker Hub and ghcr, otherwise for personal forks just run job for ghcr
-        registry: ${{ fromJSON(github.repository_owner == 'hyperledger' && '["docker.io", "ghcr.io"]' || '["ghcr.io"]') }}
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: ${{ runner.temp }}/digests/${{ matrix.registry }}
-          pattern: digests-${{ matrix.registry }}-*
-          merge-multiple: true
 
       - name: Login to the ${{ matrix.registry }} Container Registry
         uses: docker/login-action@v3
@@ -168,9 +103,6 @@ jobs:
           registry: ${{ matrix.registry }}
           username: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_USERNAME || github.actor }}
           password: ${{ matrix.registry == 'docker.io' && secrets.DOCKERHUB_TOKEN    || secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Docker meta
         id: meta
@@ -182,11 +114,20 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
 
-      - name: Create manifest list and push # combines the downloaded amd64 and arm64 digests and pushes multi-architecture manifest with the tags specified above
-        working-directory: ${{ runner.temp }}/digests/${{ matrix.registry }}
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ matrix.registry }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: images/fabric-ca/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/s390x
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            UBUNTU_VER=${{ env.UBUNTU_VER }}
+            GO_VER=${{ steps.setup-go.outputs.go-version }}
+            GO_TAGS=pkcs11
+            GO_LDFLAGS=-X github.com/hyperledger/fabric-ca/lib/metadata.Version=${{ env.FABRIC_CA_VER }}
+          push: true
 
       - name: Inspect image
         run: |
@@ -196,7 +137,7 @@ jobs:
     name: Create GitHub Release
     needs:
       - build-binaries
-      - merge-and-push-multi-arch-image
+      - build-and-push-docker-image
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ export GO_LDFLAGS
 IMAGES = $(PROJECT_NAME)
 FVTIMAGE = $(PROJECT_NAME)-fvt
 
-RELEASE_PLATFORMS = linux-amd64 linux-arm64 darwin-amd64 darwin-arm64 windows-amd64
+RELEASE_PLATFORMS = linux-amd64 linux-arm64 linux-s390x darwin-amd64 darwin-arm64 windows-amd64
 RELEASE_PKGS = fabric-ca-server fabric-ca-client
 
 TOOLS = build/tools
@@ -174,6 +174,7 @@ release/darwin-%:	GOOS=darwin
 
 release/%-amd64: 	GOARCH=amd64
 release/%-arm64: 	GOARCH=arm64
+release/%-s390x: 	GOARCH=s390x
 
 release/windows-amd64: CC=x86_64-w64-mingw32-gcc
 release/windows-amd64: $(patsubst %,release/windows-amd64/bin/%, $(RELEASE_PKGS))
@@ -192,6 +193,9 @@ release/linux-amd64: $(patsubst %,release/linux-amd64/bin/%, $(RELEASE_PKGS))
 
 release/linux-arm64: CC=aarch64-linux-gnu-gcc
 release/linux-arm64: $(patsubst %,release/linux-arm64/bin/%, $(RELEASE_PKGS))
+
+release/linux-s390x: CC=s390x-linux-gnu-gcc
+release/linux-s390x: $(patsubst %,release/linux-s390x/bin/%, $(RELEASE_PKGS))
 
 release/%/bin/fabric-ca-client: GO_TAGS+= caclient
 release/%/bin/fabric-ca-client: $(GO_SOURCE)
@@ -240,6 +244,7 @@ dist-clean:
 	-@rm -rf release/linux-amd64/hyperledger-fabric-ca-linux-amd64-$(RELEASE_VERSION).tar.gz ||:
 	-@rm -rf release/darwin-arm64/hyperledger-fabric-ca-darwin-arm64-$(RELEASE_VERSION).tar.gz ||:
 	-@rm -rf release/linux-arm64/hyperledger-fabric-ca-linux-arm64-$(RELEASE_VERSION).tar.gz ||:
+	-@rm -rf release/linux-s390x/hyperledger-fabric-ca-linux-s390x-$(RELEASE_VERSION).tar.gz ||:
 
 .FORCE:
 


### PR DESCRIPTION
<!--- DELETE MARKDOWN COMMENTS BEFORE SUBMITTING PULL REQUEST. -->

<!--- Provide a descriptive summary of your changes in the Title above. -->

#### Type of change

<!--- What type of change? Pick one option and delete the others. -->

- Improvement (improvement to code, performance, etc)

#### Description

<!--- Describe your changes in detail, including motivation. -->

This PR aims to add the `s390x` platform among the supported platforms for the Docker multiplatform image and also build the `s390x` binary using GitHub Actions.

With this PR, the pipeline will now generate:

- binaries: `linux/amd64`, `linux/arm64`, `linux/s390x`, `darwin/arm64`, `windows/amd64`;
- image: `linux/amd64`, `linux/arm64`, `linux/s390x`.

#### Additional details

<!--- Additional implementation details or comments to reviewers. -->
<!--- Summarize how the pull request was tested (if not obvious from commit). -->

For the images I've moved the workflow from native-VM to QEMU-emulation since GitHub Actions doesn't provide a native `s390x` runner. It follows the same approach that we use in [`fabric-x-orderer`](https://github.com/hyperledger/fabric-x-orderer/blob/main/.github/workflows/docker-release.yml) for the multi-platform release.

The artifacts have been correctly generated using a [test tag in my fork](https://github.com/pasquale95/fabric-ca/pkgs/container/fabric-ca).